### PR TITLE
"make dist" does not work

### DIFF
--- a/src/fglm/Makefile.am
+++ b/src/fglm/Makefile.am
@@ -1,7 +1,7 @@
 noinst_LTLIBRARIES 	= libfglm.la
 libfglm_la_SOURCES 	= fglm_core.c
 libfglm_ladir				=	$(includedir)/msolve/fglm
-libfglm_la_HEADERS	=	*.h
+libfglm_la_HEADERS	=
 libfglm_la_CFLAGS		= $(SIMD_FLAGS) $(CPUEXT_FLAGS) $(OPENMP_CFLAGS)
 
 EXTRA_DIST	=		libfglm.h \

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -19,7 +19,7 @@
  * Mohab Safey El Din */
 
 #if HAVE_CONFIG_H
-#include "../../config.h"
+#include "config.h"
 #endif
 
 #include<stdio.h>

--- a/src/msolve/Makefile.am
+++ b/src/msolve/Makefile.am
@@ -1,13 +1,17 @@
 lib_LTLIBRARIES 			= libmsolve.la
 libmsolve_la_SOURCES 	= libmsolve.c
 libmsolve_ladir				=	$(includedir)/msolve/msolve
-libmsolve_la_HEADERS	=	*.h
+libmsolve_la_HEADERS	=
 libmsolve_la_CFLAGS		= $(SIMD_FLAGS) $(CPUEXT_FLAGS) $(OPENMP_CFLAGS)
 libmsolve_la_LDFLAGS	= -release $(PACKAGE_VERSION)
 libmsolve_la_LIBADD		=	../usolve/libusolve.la ../fglm/libfglm.la ../neogb/libneogb.la
 
 EXTRA_DIST	=	  data.h \
+								msolve.h \
+								duplicate.c \
 								hilbert.c \
+								linear.c \
+								lifting.c \
 								iofiles.c \
 								msolve.c \
 								primes.c \

--- a/src/msolve/libmsolve.c
+++ b/src/msolve/libmsolve.c
@@ -19,7 +19,7 @@
  * Mohab Safey El Din */
 
 #if HAVE_CONFIG_H
-#include "../../config.h"
+#include "config.h"
 #endif
 
 #include "data.h"

--- a/src/neogb/Makefile.am
+++ b/src/neogb/Makefile.am
@@ -1,7 +1,7 @@
 lib_LTLIBRARIES 		= libneogb.la
 libneogb_la_SOURCES = libneogb.h gb.c
 libneogb_ladir			=	$(includedir)/msolve/neogb
-libneogb_la_HEADERS	=	*.h
+libneogb_la_HEADERS	=
 libneogb_la_LDFLAGS	= -release $(PACKAGE_VERSION)
 libneogb_la_CFLAGS	= $(SIMD_FLAGS) $(CPUEXT_FLAGS) $(OPENMP_CFLAGS)
 
@@ -24,6 +24,7 @@ EXTRA_DIST	=		basis.h \
 								data.c \
 								engine.c \
 								f4.c \
+								f4sat.c \
 								sba.c \
 								hash.c \
 								io.c \

--- a/src/neogb/gb.c
+++ b/src/neogb/gb.c
@@ -19,7 +19,7 @@
  * Mohab Safey El Din */
 
 #if HAVE_CONFIG_H
-#include "../../config.h"
+#include "config.h"
 #endif
 
 #include <stdio.h>

--- a/src/neogb/la.h
+++ b/src/neogb/la.h
@@ -28,7 +28,7 @@
 #ifdef _OPENMP
 #include <omp.h>
 #endif
-#include <config.h>
+#include "config.h"
 #include "types.h"
 
 #if 0

--- a/src/usolve/Makefile.am
+++ b/src/usolve/Makefile.am
@@ -1,7 +1,7 @@
 noinst_LTLIBRARIES 		= libusolve.la
 libusolve_la_SOURCES 	= usolve.c
 libusolve_ladir				=	$(includedir)/msolve/usolve
-libusolve_la_HEADERS	=	*.h
+libusolve_la_HEADERS	=
 libusolve_la_CFLAGS		= $(SIMD_FLAGS) $(CPUEXT_FLAGS) $(OPENMP_CFLAGS)
 
 EXTRA_DIST = 		bisection.h \

--- a/src/usolve/usolve.c
+++ b/src/usolve/usolve.c
@@ -19,7 +19,7 @@
  * Mohab Safey El Din */
 
 #if HAVE_CONFIG_H
-#include "../../config.h"
+#include "config.h"
 #endif
 
 #include<stdio.h>


### PR DESCRIPTION
I recommend to use `make distcheck` to create source tarballs on each release (and to automatically check that this source tarball contains all files).

I had to do this for Sage packaging of `msolve` in https://trac.sagemath.org/ticket/31664