### PR TITLE
Maple interface -- fix warning -- "implicitly declared local"

### DIFF
--- a/interfaces/msolve-to-maple-file-interface.mpl
+++ b/interfaces/msolve-to-maple-file-interface.mpl
@@ -282,7 +282,7 @@ end proc:
 # [ vars[1] = (a1+b1)/2, ..., vars[n] = (an+bn)/2 ]
 MSolveRealRoots:=proc(F, vars, opts:={})
 local results, dim, fname1, fname2, verb, param, msolve_path, file_dir,
-lsols, nl, i, gb, output, nthreads, str, sols;
+lsols, nl, i, j, gb, output, nthreads, str, sols;
    if type(F, list(polynom(rational))) = false then
      printf("First argument is not a list of polynomials with rational coefficients\n");
    end if;


### PR DESCRIPTION
In the msolve/maple interface, fix the warning
```
Warning, (in anonymous procedure within MSolveRealRoots) `j` is implicitly declared local
|msolve/interfaces/msolve-to-maple-file-interface.mpl:346|
```