### PR TITLE
Explicitly include mathrsfs package in tutorial

### DIFF
--- a/doc/msolve-tutorial.tex
+++ b/doc/msolve-tutorial.tex
@@ -293,6 +293,8 @@ colframe=white!40!black,coltext=white!25!black,colback=white
   ]{biblatex}
   \bibliography{biblio}
 
+\usepackage{mathrsfs}
+
 \begin{document}
 
 \maketitle


### PR DESCRIPTION
It must be implicitly included by some other packages in newer TeX distributions, but the tutorial fails to build using the TeX packages in Ubuntu 18.04, complaining that `\mathscr` is undefined.