### PR TITLE
adding pkg-config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,5 @@ libtool
 ltmain.sh
 missing
 stamp-h1
+msolve.pc
 /msolve

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,3 +37,6 @@ fglm_build_matrixn_nonradical_shape_31_SOURCES = test/fglm/build_matrixn_nonradi
 fglm_build_matrixn_nonradical_radicalshape_31_SOURCES = test/fglm/build_matrixn_nonradical_radicalshape-31.c
 
 TESTS = $(check_PROGRAMS) $(checkdiff)
+
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = msolve.pc

--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,7 @@ AC_CHECK_FUNCS([floor getdelim gettimeofday memmove memset pow sqrt strchr strst
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
  Makefile
+ msolve.pc
  src/fglm/Makefile
  src/neogb/Makefile
  src/usolve/Makefile

--- a/msolve.pc.in
+++ b/msolve.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: msolve
+URL: https://msolve.lip6.fr/
+Description: C library for for solving multivariate polynomial systems
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lmsolve -lflint -lmpfr -lgmp
+Cflags: -I${includedir}

--- a/msolve.pc.in
+++ b/msolve.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: msolve
 URL: https://msolve.lip6.fr/
-Description: C library for for solving multivariate polynomial systems
+Description: C library for solving multivariate polynomial systems
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lmsolve -lflint -lmpfr -lgmp
 Cflags: -I${includedir}


### PR DESCRIPTION
This allows to check library availability from a script, get its flags etc.

Very important for projects like SageMath, so that we can easily use a system-wide version, if it's installed