### PR TITLE
make install:  headers to $prefix/include/msolve

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,5 @@
 AUTOMAKE_OPTIONS = color-tests
-SUBDIRS = src/usolve src/fglm src/neogb src/msolve/
+SUBDIRS = src/usolve src/fglm src/neogb src/msolve include
 
 AM_CFLAGS	= $(SIMD_FLAGS) $(CPUEXT_FLAGS) $(OPENMP_CFLAGS)
 LDADD 		= src/neogb/libneogb.la src/fglm/libfglm.la src/usolve/libusolve.la

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_FILES([
  Makefile
  msolve.pc
+ include/Makefile
  src/fglm/Makefile
  src/neogb/Makefile
  src/usolve/Makefile

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,0 +1,1 @@
+nobase_include_HEADERS = msolve/msolve.h msolve/msolve-data.h  

--- a/include/msolve/msolve-data.h
+++ b/include/msolve/msolve-data.h
@@ -1,0 +1,1 @@
+../../src/msolve/msolve-data.h

--- a/include/msolve/msolve.h
+++ b/include/msolve/msolve.h
@@ -1,0 +1,1 @@
+../../src/msolve/msolve.h


### PR DESCRIPTION
provide autotools magic for installing headers

In the source, msolve's headers are symbolic links in include/msolve/ pointing to .h files in src/msolve/
Copies of these files are installed in $prefix/include/msolve/

It will fix #64 