### PR TITLE
Make msolve build with flint 3 alpha

### DIFF
--- a/src/fglm/berlekamp_massey.c
+++ b/src/fglm/berlekamp_massey.c
@@ -30,6 +30,9 @@
 */
 
 #include <stdlib.h>
+#if __FLINT_VERSION >= 3
+#  include <flint/nmod.h>
+#endif
 //#include "nmod_poly.h"
 //#include "mpn_extras.h"
 

--- a/src/fglm/data_fglm.c
+++ b/src/fglm/data_fglm.c
@@ -24,6 +24,7 @@
 #include <flint/mpn_extras.h>
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_factor.h>
+#include <flint/ulong_extras.h>
 
 
 typedef uint32_t szmat_t;
@@ -299,9 +300,11 @@ static inline void nmod_poly_set_prime(nmod_poly_t poly,
   mp_limb_t ninv = n_preinvert_limb(prime);
   poly->mod.n = prime;
   poly->mod.ninv = ninv;
+#if __FLINT_VERSION < 3
   count_leading_zeros(poly->mod.norm, prime);
-  /* poly->mod.norm = flint_clz(prime); */
-
+#else
+  poly->mod.norm = flint_clz(prime);
+#endif
 }
 
 static inline void fglm_param_set_prime(param_t *param, mp_limb_t prime){


### PR DESCRIPTION
...while remaining compatible with flint2.

There are still some warnings that I think should be fixed on the flint
side, see https://github.com/flintlib/flint2/issues/1390.
