### PR TITLE
Addition of new basis elements in f4

### DIFF
--- a/src/neogb/convert.c
+++ b/src/neogb/convert.c
@@ -611,9 +611,13 @@ static void convert_sparse_matrix_rows_to_basis_elements(
 
     /* fix size of basis for entering new elements directly */
     check_enlarge_basis(bs, mat->np, st);
+    while (bht->esz - bht->eld < mat->ncr) {
+        enlarge_hash_table(bht);
+    }
 
     hm_t **rows = mat->tr;
-
+#pragma omp parallel for num_threads(st->nthrds) \
+    private(i, j, k)
     for (k = 0; k < np; ++k) {
         /* We first insert the highest leading monomial element to the basis
          * for a better Gebauer-Moeller application when updating the pair

--- a/src/neogb/convert.c
+++ b/src/neogb/convert.c
@@ -600,9 +600,9 @@ static void convert_sparse_matrix_rows_to_basis_elements(
     len_t i, j, k;
     deg_t deg;
 
-    const len_t bl  = bs->ld;
-    const len_t np  = mat->np;
-    const hi_t * const hcm = st->hcm;
+    const len_t bl = bs->ld;
+    const len_t np = mat->np;
+    hi_t *hcm      = st->hcm;
 
     /* timings */
     double ct0, ct1, rt0, rt1;
@@ -611,11 +611,9 @@ static void convert_sparse_matrix_rows_to_basis_elements(
 
     /* fix size of basis for entering new elements directly */
     check_enlarge_basis(bs, mat->np, st);
-    while (bht->esz - bht->eld < mat->ncr) {
-        enlarge_hash_table(bht);
-    }
 
     hm_t **rows = mat->tr;
+    switch_hcm_data_to_basis_hash_table(hcm, bht, mat, sht);
 #pragma omp parallel for num_threads(st->nthrds) \
     private(i, j, k)
     for (k = 0; k < np; ++k) {
@@ -627,7 +625,10 @@ static void convert_sparse_matrix_rows_to_basis_elements(
         } else {
             i = k;
         }
-        insert_in_basis_hash_table_pivots(rows[i], bht, sht, hcm, st);
+        const len_t len = rows[i][LENGTH]+OFFSET;
+        for (j = OFFSET; j < len; ++j) {
+            rows[i][j] = hcm[rows[i][j]];
+        }
         deg = bht->hd[rows[i][OFFSET]].deg;
         if (st->nev > 0) {
             const len_t len = rows[i][LENGTH]+OFFSET;

--- a/src/neogb/hash.c
+++ b/src/neogb/hash.c
@@ -1036,6 +1036,26 @@ restart:
     psl->ld = m;
 }
 
+static inline void switch_hcm_data_to_basis_hash_table(
+    hi_t *hcm,
+    ht_t *bht,
+    const mat_t *mat,
+    const ht_t * const sht
+    )
+{
+    const len_t start = mat->ncl;
+    const len_t end   = mat->nc;
+
+    while (bht->esz - bht->eld < mat->ncr) {
+        enlarge_hash_table(bht);
+    }
+
+    for (len_t i = start; i < end; ++i) {
+        hcm[i] = check_insert_in_hash_table(
+                sht->ev[hcm[i]], sht->hd[hcm[i]].val, bht);
+    }
+}
+
 static inline void insert_in_basis_hash_table_pivots(
     hm_t *row,
     ht_t *bht,

--- a/src/neogb/hash.c
+++ b/src/neogb/hash.c
@@ -1046,9 +1046,9 @@ static inline void insert_in_basis_hash_table_pivots(
 {
     len_t l;
 
-    while (bht->esz - bht->eld < row[LENGTH]) {
+    /* while (bht->esz - bht->eld < row[LENGTH]) {
         enlarge_hash_table(bht);
-    }
+    } */
 
     const len_t len = row[LENGTH]+OFFSET;
     const len_t evl = bht->evl;
@@ -1058,10 +1058,10 @@ static inline void insert_in_basis_hash_table_pivots(
     
     exp_t *evt  = (exp_t *)malloc(
         (unsigned long)(st->nthrds * evl) * sizeof(exp_t));
-#if PARALLEL_HASHING
+/* #if PARALLEL_HASHING
 #pragma omp parallel for num_threads(st->nthrds) \
     private(l)
-#endif
+#endif */
     for (l = OFFSET; l < len; ++l) {
         exp_t *evtl = evt + (omp_get_thread_num() * evl);
         memcpy(evtl, evs[hcm[row[l]]],


### PR DESCRIPTION
Optimizes the parallel addition of new basis elements in f4:

1. Sequential moving sht monomials to bht.
2. Parallel adding new polynomials to basis.

This improves runtime and memory usage particularly for bigger examples and many cores (>16).