### PR TITLE
fixing issue "redefinition of ..." due to new functionalities in Flint 3.0

### DIFF
--- a/src/upolmat/nmod_mat_poly.h
+++ b/src/upolmat/nmod_mat_poly.h
@@ -33,7 +33,7 @@
  * from `nmod_poly_mat` format and use the relevant functions for that format.
  *
  * \todo benchmark performance
- * \todo test for memory leaks
+ * \todo more tests for memory leaks
  * \todo Note: all parameters are supposed init
  *
  * \todo transpose, swap/permute rows/cols

--- a/src/upolmat/nmod_poly_mat_utils.c
+++ b/src/upolmat/nmod_poly_mat_utils.c
@@ -77,15 +77,18 @@ void nmod_poly_mat_degree_matrix(fmpz_mat_t dmat,
             *fmpz_mat_entry(dmat, i, j) = nmod_poly_degree(nmod_poly_mat_entry(mat, i, j));
 }
 
+#if __FLINT_VERSION < 3
 void nmod_poly_mat_truncate(nmod_poly_mat_t pmat, long len)
 {
     for (slong i = 0; i < pmat->r; i++)
         for (slong j = 0; j < pmat->c; j++)
             nmod_poly_truncate(pmat->rows[i] + j, len);
 }
+#endif
 
 
-void nmod_poly_mat_print_pretty(const nmod_poly_mat_t mat, const char * var)
+#if __FLINT_VERSION < 3
+void nmod_poly_mat_print(const nmod_poly_mat_t mat, const char * var)
 {
     slong rdim = mat->r, cdim = mat->c;
 
@@ -107,6 +110,7 @@ void nmod_poly_mat_print_pretty(const nmod_poly_mat_t mat, const char * var)
     }
     flint_printf("]\n");
 }
+#endif
 
 
 void nmod_poly_mat_degree_matrix_print_pretty(const nmod_poly_mat_t mat)

--- a/src/upolmat/nmod_poly_mat_utils.h
+++ b/src/upolmat/nmod_poly_mat_utils.h
@@ -63,8 +63,10 @@ void nmod_poly_mat_middle_product(nmod_poly_mat_t res,
                                   slong d,
                                   slong h);
 
+#if __FLINT_VERSION < 3
 /** Truncate `pmat` at order `len` */
 void nmod_poly_mat_truncate(nmod_poly_mat_t pmat, long len);
+#endif
 
 
 
@@ -144,8 +146,10 @@ nmod_poly_mat_set_from_mat_poly(nmod_poly_mat_t pmat,
 /*------------------------------------------------------------*/
 /*------------------------------------------------------------*/
 
+#if __FLINT_VERSION < 3
 /** Matrix pretty print to standard output */
-void nmod_poly_mat_print_pretty(const nmod_poly_mat_t mat, const char * var);
+void nmod_poly_mat_print(const nmod_poly_mat_t mat, const char * var);
+#endif
 
 
 /** Print the degree matrix, see @ref DegreeMatrix */


### PR DESCRIPTION
msolve was not compiling against the recent Flint 3.0, due to basic `nmod_poly_mat`  functions that are now part of Flint itself. This PR fixes this issue.