### PR TITLE
Fix spelling of "hyperref" option to xcolor package

### DIFF
--- a/doc/msolve-tutorial.tex
+++ b/doc/msolve-tutorial.tex
@@ -15,7 +15,7 @@
 \usepackage[utf8]{inputenc}
 \usepackage[english]{babel}
 \usepackage{amsmath,amssymb,amsfonts,amsthm}
-\usepackage[usenames,dvipsnames,svgnames,table,hyperef]{xcolor}
+\usepackage[usenames,dvipsnames,svgnames,table,hyperref]{xcolor}
 \usepackage{eurosym}
 \usepackage{listings}
 \lstset{


### PR DESCRIPTION
This was causing a build error in the Debian package (see https://bugs.debian.org/1058557).

Note that the `hyperref` option is now obsolete (see https://mirror.las.iastate.edu/tex-archive/macros/latex/contrib/xcolor/xcolor.pdf), but I suppose it might be good to keep around for building the docs with older versions of TeX.