### PR TITLE
Basis hash tables

### DIFF
--- a/src/msolve/duplicate.c
+++ b/src/msolve/duplicate.c
@@ -353,7 +353,7 @@ static inline void duplicate_data_mthread_gbtrace(int nthreads,
                                                   int32_t **leadmons_current,
                                                   trace_t **btrace){
 
-  const long len = num_gb[0] * (st->nvars);
+  const long len = num_gb[0] * (st->nvars-st->nev);
   for(int i = 0; i < nthreads; i++){
     leadmons_current[i] = (int32_t *)calloc(len, sizeof(int32_t));
   }

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1304,7 +1304,7 @@ int msolve_gbtrace_qq(
     /* copy of hash tables for tracer application */
     msd->blht[0] = msd->bht;
     for(int i = 1; i < st->nthrds; i++){
-      ht_t *lht = copy_hash_table(msd->bht, st);
+      ht_t *lht = copy_hash_table(msd->bht);
       msd->blht[i] = lht;
     }
 

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -760,7 +760,7 @@ static void gb_modular_trace_application(gb_modpoly_t modgbs,
   }
   if (lml != num_gb[0]) {
       if (bs != NULL) {
-        free_basis_without_hash_table(&bs);
+        free_basis_and_only_local_hash_table_data(&bs);
       }
       return;
   }
@@ -783,7 +783,7 @@ static void gb_modular_trace_application(gb_modpoly_t modgbs,
   }
 
   if (bs != NULL) {
-    free_basis_without_hash_table(&bs);
+    free_basis_and_only_local_hash_table_data(&bs);
   }
 
 }

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -586,7 +586,7 @@ static int32_t * gb_modular_trace_learning(gb_modpoly_t modgbs,
                                            trace_t *trace,
                                            ht_t *tht,
                                            bs_t *bs_qq,
-                                           ht_t *bht,
+                                           ht_t *gbht,
                                            md_t *st,
                                            const int32_t fc,
                                            int info_level,
@@ -604,7 +604,8 @@ static int32_t * gb_modular_trace_learning(gb_modpoly_t modgbs,
 
     bs_t *bs = NULL;
     /* if(gens->field_char){ */
-    int32_t err = 0;
+    int32_t err     = 0;
+    st->f4_qq_round = 1;
     bs = core_gba(bs_qq, st, &err, fc);
     if (err) {
       printf("Problem with F4, stopped computation.\n");
@@ -612,6 +613,8 @@ static int32_t * gb_modular_trace_learning(gb_modpoly_t modgbs,
     }
 
     rt = realtime()-ca0;
+
+    const ht_t *bht = bs->ht;
 
     if(info_level > 1){
         fprintf(stderr, "Learning phase %.2f Gops/sec\n",
@@ -704,7 +707,7 @@ static void gb_modular_trace_application(gb_modpoly_t modgbs,
                                          trace_t **btrace,
                                          ht_t **btht,
                                          bs_t *bs_qq,
-                                         ht_t **bht,
+                                         ht_t **gbht,
                                          md_t *st,
                                          const int32_t fc,
                                          int info_level,
@@ -718,7 +721,8 @@ static void gb_modular_trace_application(gb_modpoly_t modgbs,
                                          int *bad_primes){
 
   double rt = realtime();
-  st->info_level = 0;
+  st->info_level  = 0;
+  st->f4_qq_round = 2;
   /* tracing phase */
 
   /* F4 and FGLM are run using a single thread */
@@ -737,6 +741,7 @@ static void gb_modular_trace_application(gb_modpoly_t modgbs,
     bs = gba_trace_application_phase(btrace[0], btht[0], bs_qq, bht[0], st, lp->p[0]);
   }
   */
+  ht_t **bht = &(bs->ht);
   if (bs == NULL) {
       bad_primes[0] = 1;
       return;

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -2411,7 +2411,7 @@ static void secondary_modular_steps(sp_matfglm_t **bmatrix,
             bad_primes[i] = 1;
         }
         if (bs[i] != NULL) {
-            free_basis_without_hash_table(&(bs[i]));
+            free_basis_and_only_local_hash_table_data(&(bs[i]));
         }
     }
     st->nthrds = nthrds;
@@ -5204,7 +5204,7 @@ restart:
 
             int i;
 
-            ht_t *lht = copy_hash_table(bht, st);
+            ht_t *lht = copy_hash_table(bht);
 
             prime = next_prime(1<<30);
 
@@ -5421,7 +5421,7 @@ restart:
 
             int i;
 
-            ht_t *lht = copy_hash_table(bht, st);
+            ht_t *lht = copy_hash_table(bht);
 
             prime = next_prime(1<<30);
 

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1856,7 +1856,8 @@ static int32_t *initial_modular_step(
 {
     double rt = realtime();
 
-    md->print_gb = print_gb;
+    md->print_gb    = print_gb;
+    md->f4_qq_round = 1;
 
     int32_t error              = 0;
     int32_t empty_solution_set = 1;
@@ -2328,7 +2329,8 @@ static void secondary_modular_steps(sp_matfglm_t **bmatrix,
                                    const long nbsols,
                                    int *bad_primes)
 {
-    st->info_level = 0;
+    st->info_level  = 0;
+    st->f4_qq_round = 2;
 
     double rt = realtime();
     /* tracing phase */

--- a/src/neogb/basis.c
+++ b/src/neogb/basis.c
@@ -80,6 +80,14 @@ void free_basis(
     free_basis_without_hash_table(bsp);
 }
 
+void free_basis_and_only_local_hash_table_data(
+        bs_t **bsp
+        )
+{
+    free_hash_table(&((*bsp)->ht));
+    free_basis_without_hash_table(bsp);
+}
+
 void free_basis_without_hash_table(
         bs_t **bsp
         )
@@ -383,7 +391,11 @@ bs_t *copy_basis_mod_p(
     bs->lml         = gbs->lml;
     bs->sz          = gbs->sz;
     bs->constant    = gbs->constant;
-    bs->ht          = gbs->ht;
+    if (st->f4_qq_round != 1) {
+        bs->ht = copy_hash_table(gbs->ht);
+    } else {
+        bs->ht = gbs->ht;
+    }
     bs->hm          = (hm_t **)malloc((unsigned long)bs->sz * sizeof(hm_t *));
     bs->lm          = (sdm_t *)malloc((unsigned long)bs->sz * sizeof(sdm_t));
     bs->lmps        = (bl_t *)malloc((unsigned long)bs->sz * sizeof(bl_t));

--- a/src/neogb/basis.h
+++ b/src/neogb/basis.h
@@ -27,6 +27,10 @@ void free_basis_without_hash_table(
         bs_t **bsp
         );
 
+void free_basis_and_only_local_hash_table_data(
+        bs_t **bsp
+        );
+
 void free_basis(
         bs_t **bsp
         );

--- a/src/neogb/data.h
+++ b/src/neogb/data.h
@@ -40,7 +40,7 @@ inline omp_int_t omp_get_thread_num(void) { return 0;}
 inline omp_int_t omp_get_max_threads(void) { return 1;}
 #endif
 
-#define PARALLEL_HASHING 1
+#define PARALLEL_HASHING 0
 #define ORDER_COLUMNS 1
 /* loop unrolling in sparse linear algebra:
  * we store the offset of the first elements not unrolled

--- a/src/neogb/data.h
+++ b/src/neogb/data.h
@@ -402,6 +402,7 @@ struct md_t
     int32_t size_basis;
     int32_t ff_bits;
     int32_t nf;
+    int32_t f4_qq_round;
     int32_t use_signatures; /* module monomial ordering:
                                0 = off,
                                1=SCHREYER,

--- a/src/neogb/f4.c
+++ b/src/neogb/f4.c
@@ -592,7 +592,7 @@ static void finalize_f4(
         )
 {
     if (err > 0) {
-        free_basis(bsp);
+        free_basis_and_only_local_hash_table_data(bsp);
     }
 
     if ((*lmdp)->trace_level == LEARN_TRACER) {
@@ -649,7 +649,7 @@ bs_t *core_f4(
         print_round_timings(stdout, md, rrt, crt);
     }
     if (*errp > 0) {
-        free_basis(&bs);
+        free_basis_and_only_local_hash_table_data(&bs);
     } else {
         print_round_information_footer(stdout, md);
 

--- a/src/neogb/f4.c
+++ b/src/neogb/f4.c
@@ -649,7 +649,7 @@ bs_t *core_f4(
         print_round_timings(stdout, md, rrt, crt);
     }
     if (*errp > 0) {
-        free_basis_without_hash_table(&bs);
+        free_basis(&bs);
     } else {
         print_round_information_footer(stdout, md);
 

--- a/src/neogb/hash.c
+++ b/src/neogb/hash.c
@@ -128,8 +128,7 @@ ht_t *initialize_basis_hash_table(
 }
 
 ht_t *copy_hash_table(
-    const ht_t *bht,
-    const md_t *st
+    const ht_t *bht
     )
 {
     hl_t j;
@@ -1051,8 +1050,12 @@ static inline void switch_hcm_data_to_basis_hash_table(
     }
 
     for (len_t i = start; i < end; ++i) {
+#if PARALLEL_HASHING
         hcm[i] = check_insert_in_hash_table(
                 sht->ev[hcm[i]], sht->hd[hcm[i]].val, bht);
+#else
+        hcm[i] = insert_in_hash_table(sht->ev[hcm[i]], bht);
+#endif
     }
 }
 

--- a/src/neogb/hash.h
+++ b/src/neogb/hash.h
@@ -43,8 +43,7 @@ ht_t *initialize_basis_hash_table(
     );
 
 ht_t *copy_hash_table(
-    const ht_t *bht,
-    const md_t *st
+    const ht_t *bht
     );
 
 ht_t *initialize_secondary_hash_table(


### PR DESCRIPTION
This PR fixes the parallel handling of a single globel basis hash table which could have led to segmentation faults during enlargement of the table.