### PR TITLE
exit with 0 for msolve -h

### DIFF
--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -170,7 +170,7 @@ static void getoptions(
       break;
     case 'h':
       display_help(argv[0]);
-      exit(1);
+      exit(0);
     case 'e':
       *elim_block_len = strtol(optarg, NULL, 10);
       if (*elim_block_len < 0) {


### PR DESCRIPTION
There is nothing wrong with calling `msolve -h`, it should not return something that indicates an error.

This will fix #131 