### PR TITLE
fix missing include for flint 3.1.2

### DIFF
--- a/src/usolve/univmultiply.c
+++ b/src/usolve/univmultiply.c
@@ -23,16 +23,21 @@
 #ifdef _OPENMP
 #include<omp.h>
 #endif
+
 #define USEFLINT 1
 
 #ifdef USEFLINT
-#include "flint/flint.h"
-#include "flint/fmpz.h"
-#include "flint/fft.h"
-#include "flint/fft_tuning.h"
-#include "flint/fmpz_poly.h"
+  #include "flint/flint.h"
+  #include "flint/fmpz.h"
+//  #include "flint/fft.h"
+//  #if __FLINT_VERSION < 3
+//      || (__FLINT_VERSION == 3 && __FLINT_VERSION_MINOR == 0)
+//      || (__FLINT_VERSION == 3 && __FLINT_VERSION_MINOR == 1 && __FLINT_VERSION_PATCHLEVEL < 2)
+//    #include "flint/fft_tuning.h"
+//  #endif
+  #include "flint/fmpz_poly.h"
 #else
-#include"mpz_upoly_multiply.h"
+  #include"mpz_upoly_multiply.h"
 #endif
 
 #ifdef USEFLINT


### PR DESCRIPTION
In fact it seems this include was just not needed anyway. In case this is needed in the future: the corresponding files fft_tuning{32,64}.in were removed from flint in this commit  https://github.com/flintlib/flint/commit/0672a560daf32050d7bce979329f9221fe9e7098 