### PR TITLE
Fixes INSTALL description for MAC OS users and adds a link to the interfaces in msolve-tutorial

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -9,9 +9,9 @@ You will need to have autotools installed on your system.
 5. Run `make install` in order to globally install the library and the binary
    of msolve.
 
-If you are working on a distriubtion (downloaded *.tar.gz)
+If you are working on a distribution (downloaded *.tar.gz)
 ==========================================================
-1. Run `./configure` (possibly with options, see ./configure -help for more
+1. Run `./configure` (possibly with options, see `./configure -help` for more
    information).
 2. Run `make` (possibly with CFLAGS and LDFLAGS adjusted).
 3. Run `make check`.
@@ -20,14 +20,14 @@ If you are working on a distriubtion (downloaded *.tar.gz)
 
 NOTE TO MAC OS users
 ====================
-To build a static binary file, you may need to run `./configure -static`.
+To build a static binary file, you may need to run `./configure --enable-static`.
 
 You may also need to proceed slightly differently by modifying the `Makefile` file as follows
 - add to the `LIBS` variable the `-fopenmp` option
 ```
 LIBS = -lflint -lmpfr -lgmp -lm -fopenmp
 ```
-- change the `CC` variable to your actual `gcc` compiler, e.g. 
+- change the `CC` variable to your actual `gcc` compiler, e.g.
 ```
 CC = gcc-11
 ```

--- a/doc/msolve-tutorial.tex
+++ b/doc/msolve-tutorial.tex
@@ -1173,7 +1173,7 @@ inside Julia\\[1em]
 \section{Maple interface to \msolve}
 
 The Maple interface to \msolve is a file interface which can be found on the
-\msolve homepage or in the \msolve binary package. Having loaded the interface
+\msolve \href{https://msolve.lip6.fr/interfaces/index.html}{homepage} or in the \msolve binary package. Having loaded the interface
 one can call the function
 \texttt{MSolveRealRoots()} in the following way:\\[1em]
 \texttt{results = MSolveRealRoots(F, vars)}\\[1em]


### PR DESCRIPTION
Thanks to Bruno Salvy for reporting on these issues and to Ludovic Perret for giving the right configure command on MAC OS.