### PR TITLE
Allow passing the field of rational numbers in maple interface

### DIFF
--- a/interfaces/msolve-to-maple-file-interface-macos.mpl
+++ b/interfaces/msolve-to-maple-file-interface-macos.mpl
@@ -221,12 +221,10 @@ field_char, lsols, nl, i, gb, output, nthreads, str, elim;
          error "Field characteristic is too large to be supported";
       end if;
 
-      if fc > 0 then
-         field_char := fc;
-      end if;
+      field_char := fc;
 
    else
-      printf("Second argument should be a prime integer < 2^31\n");
+      printf("Second argument should be 0 or a prime integer < 2^31\n");
    end if;
    if not(indets(F) subset indets(vars)) then
      printf("Given variables do not match the variables in the input polynomials\n");

--- a/interfaces/msolve-to-maple-file-interface.mpl
+++ b/interfaces/msolve-to-maple-file-interface.mpl
@@ -223,12 +223,10 @@ field_char, lsols, nl, i, gb, output, nthreads, str, elim;
          error "Field characteristic is too large to be supported";
       end if;
 
-      if fc > 0 then
-         field_char := fc;
-      end if;
+      field_char := fc;
 
    else
-      printf("Second argument should be a prime integer < 2^31\n");
+      printf("Second argument should be 0 or a prime integer < 2^31\n");
    end if;
    if not(indets(F) subset indets(vars)) then
      printf("Given variables do not match the variables in the input polynomials\n");


### PR DESCRIPTION
`fc = 0` was previously not handled in `MSolveGroebner`, causing an undefined `field_char` and subsequent failures when passed to `ToMSolve`.

Tested with the following lines, saved as `test.mpl` in the project root directory, with a global installation of `msolve` on macOS.

```maple
read("interfaces/msolve-to-maple-file-interface-macos.mpl");
MSolveGroebner([x^2 + y^2 - 4, x * y - 1], 0, [x, y], ["mspath" = "msolve"]);
```