### PR TITLE
Rework printing information for FGLM and lifting of Gröbner bases

### DIFF
--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -92,7 +92,7 @@ void print_fglm_data(
       fprintf(file, "density of the nonfree part     %5.1f%%\n", 100*matrix->nonfreepartdensity);
     }
     fprintf(file, "deg. elim. pol.    %16lu\n", (unsigned long)param->degelimpol);
-    
+
     fprintf(file, "deg. sqfr. elim. pol. %13lu\n", (unsigned long)param->degsqfrelimpol);
     fprintf(file, "-----------------------------------------\n\n");
   }
@@ -423,7 +423,7 @@ static inline void solveHankel(nmod_poly_t param,
  Mirroring them will give an array of length d + 1
  */
 
-static inline void solve_hankel(fglm_bms_data_t *data_bms, 
+static inline void solve_hankel(fglm_bms_data_t *data_bms,
                                 szmat_t dimquot,
                                 szmat_t dim,
                                 szmat_t block_size,
@@ -449,13 +449,13 @@ static inline void solve_hankel(fglm_bms_data_t *data_bms,
   nmod_poly_mullow(data_bms->A, data_bms->rZ1, data_bms->V, dim); // mod t^dim
   nmod_poly_mullow(data_bms->B, data_bms->Z2, data_bms->V, dim); // mod t^dim
 
-  mirror_poly_solve(data_bms->rZ1, data_bms->B, dim); 
+  mirror_poly_solve(data_bms->rZ1, data_bms->B, dim);
 
   for(szmat_t i = 0; i < dim ; i++){
     data_bms->B->coeffs[i] = data_bms->rZ1->coeffs[i];
   }
   data_bms->B->length = data_bms->rZ1->length;
-  mirror_poly_solve(data_bms->rZ1, data_bms->A, dim); 
+  mirror_poly_solve(data_bms->rZ1, data_bms->A, dim);
   for(szmat_t i = 0; i < dim ; i++){
     data_bms->A->coeffs[i] = data_bms->rZ1->coeffs[i];
   }
@@ -864,7 +864,7 @@ static inline long make_square_free_elim_poly(param_t *param,
                                               int info_level){
   long dim = data_bms->BMS->V1->length - 1;
   param->degelimpol = dim;
-  
+
   int boo = nmod_poly_is_squarefree(data_bms->BMS->V1);
 
   if(boo && dim == dimquot){
@@ -874,7 +874,6 @@ static inline long make_square_free_elim_poly(param_t *param,
   else{
 
     if(boo==0){
-      /* JB to change */
       /* if(info_level){ */
       /*   fprintf(stderr, "Minimal polynomial is not square-free\n"); */
       /* } */
@@ -887,7 +886,6 @@ static inline long make_square_free_elim_poly(param_t *param,
       nmod_poly_mul(param->elim, param->elim, data_bms->sqf->p+i);
     }
     param->degsqfrelimpol = param->elim->length-1;
-    /* JB to change */
     /* if(info_level){ */
     /*   fprintf(stderr, "Degree of the square-free part: %ld\n", */
     /*           param->elim->length-1); */
@@ -904,14 +902,13 @@ static inline long make_square_free_elim_poly_colon(param_t *param,
 						    long dimquot,
 						    int info_level){
   long dim = data_bms->BMS->V1->length - 1;
-  
+
   int boo = nmod_poly_is_squarefree(data_bms->BMS->V1);
 
   if(boo){
     nmod_poly_set(param->elim, data_bms->BMS->V1);
   }
   else{
-    /* JB to change */
     /* if(info_level){ */
     /*   fprintf(stderr, "Minimal polynomial is not square-free\n"); */
     /* } */
@@ -920,7 +917,6 @@ static inline long make_square_free_elim_poly_colon(param_t *param,
     for(ulong i = 0; i < data_bms->sqf->num; i++){
       nmod_poly_mul(param->elim, param->elim, data_bms->sqf->p+i);
     }
-    /* JB to change */
     /* if(info_level){ */
     /*   fprintf(stderr, "Degree of the square-free part: %ld\n", */
     /*           param->elim->length-1); */
@@ -1254,7 +1250,7 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
         divide_table_polynomials(param,data,data_bms, dimquot, block_size, prime,
                                  nc + 1-dec,0);
         if(data_bms->BMS->R1->length>0){
-          nmod_poly_neg(param->coords[nvars-2-nc], data_bms->BMS->R1); 
+          nmod_poly_neg(param->coords[nvars-2-nc], data_bms->BMS->R1);
         }
         else{
           nmod_poly_fit_length(param->coords[nvars-2-nc],
@@ -1635,7 +1631,7 @@ param_t *nmod_fglm_compute(sp_matfglm_t *matrix, const mod_t prime, const nvars_
   }
 
 
-  if (dimquot == dim) { 
+  if (dimquot == dim) {
 
     if(info_level){
       fprintf(stderr, "Elimination polynomial is squarefree.\n");
@@ -1729,7 +1725,6 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   szmat_t sz = matrix->ncols * matrix->nrows;
   szmat_t nb = initialize_fglm_data(matrix, *bdata, prime, sz, block_size);
 
-  /* JB to change */
   /* if(info_level){ */
   /*   fprintf(stderr, "[%u, %u], Dense / Total = %.2f%%\n", */
   /*           matrix->ncols, matrix->nrows, */
@@ -1756,7 +1751,7 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 #else
   if (info_level > 1) {
     fprintf(stdout,
-	    "Krylov sequence                                     ");
+	    "scalar sequence                                     ");
     fflush(stdout);
   }
   generate_sequence_verif(matrix, *bdata, block_size, dimquot,
@@ -1797,11 +1792,10 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 
   if (dimquot == dim) {
 
-    /* JB to change */
     /* if(info_level){ */
     /*   fprintf(stderr, "Elimination polynomial has degree %d.\n", dimquot); */
     /* } */
-    
+
     st_fglm = realtime();
     cst_fglm = cputime();
     if (info_level > 1){
@@ -1809,7 +1803,7 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 	      "parametrizations                                    ");
       fflush(stdout);
     }
-      
+
     if(compute_parametrizations(param, *bdata, *bdata_bms,
                                 dim, dimquot, block_size,
                                 nlins, linvars, lineqs,
@@ -1927,7 +1921,7 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
 
   /* block-size in  data->res */
   /* to store the terms we need */
-  const szmat_t block_size = bsz; 
+  const szmat_t block_size = bsz;
 
 
   fglm_param_set_prime(param, prime);
@@ -2065,7 +2059,7 @@ guess_sequence_colon(sp_matfglmcol_t *matrix, fglm_data_t * data,
   uint32_t pi2 = (uint64_t)pow(2, 32) / RED_32;
 
   uint64_t * data_backup = (uint64_t *) malloc (2 * matrix->ncols * sizeof(uint64_t));
-  
+
   uint64_t acc = 0;
   uint64_t * accparam = (uint64_t *) calloc (2 * (nvars-1),sizeof(uint64_t));
   for(szmat_t j = 0; j < matrix->ncols; j++){
@@ -2114,7 +2108,7 @@ guess_sequence_colon(sp_matfglmcol_t *matrix, fglm_data_t * data,
     }
     data->pts[i] = acc;
     data_backup[i] = acc;
-    
+
 #if DEBUGFGLM > 1
     print_vec(stdout, data->res, 2*block_size * matrix->ncols);
 #endif
@@ -2171,7 +2165,7 @@ static inline void generate_sequence_colon(sp_matfglmcol_t *matrix,
     acc = (acc + (((uint64_t)leftvec[j]) * data->vecinit[j])) % prime;
   }
   data->res[0]= acc;
-  
+
   for(szmat_t i = 1; i < matrix->ncols; i++){
     sparse_mat_fglm_colon_mult_vec(data->vvec, matrix,
 				   data->vecinit, data->vecmult,
@@ -2274,8 +2268,8 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
     return NULL;
   }
 
-  
-  
+
+
   /* szmat_t block_size = nvars-nlins; //taille de bloc dans data->res */
   szmat_t block_size = 2*nvars-1; //taille de bloc dans data->res
   /* for storing sequences terms we need to keep */

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -85,16 +85,15 @@ void print_fglm_data(
     fprintf(file, "\n---------- COMPUTATIONAL DATA -----------\n");
     fprintf(file, "degree of ideal    %16lu\n", (unsigned long)matrix->ncols);
     fprintf(file, "#dense rows        %16lu\n", (unsigned long)matrix->nrows);
+    fprintf(file, "#normal forms      %16lu\n", (unsigned long)matrix->nnfs);
+    fprintf(file, "total density                   %5.1f%%\n", 100*matrix->totaldensity);
+    fprintf(file, "density of the free part        %5.1f%%\n", 100*matrix->freepartdensity);
     if(matrix->nnfs){
-      fprintf(file, "#normal forms      %16lu\n", (unsigned long)matrix->nnfs);
-    }
-    fprintf(file, "total density                    %3.2f%%\n", 100*matrix->totaldensity);
-    fprintf(file, "density of the free part         %3.2f%%\n", 100*matrix->freepartdensity);
-    if(matrix->nnfs){
-      fprintf(file, "density of the nonfree part      %3.2f%%\n", 100*matrix->nonfreepartdensity);
+      fprintf(file, "density of the nonfree part     %5.1f%%\n", 100*matrix->nonfreepartdensity);
     }
     fprintf(file, "deg. elim. pol.    %16lu\n", (unsigned long)param->degelimpol);
-    fprintf(file, "deg. sqfr. elim. pol. %13lu\n", (unsigned long)(param->elim->length-1));
+    
+    fprintf(file, "deg. sqfr. elim. pol. %13lu\n", (unsigned long)param->degsqfrelimpol);
     fprintf(file, "-----------------------------------------\n\n");
   }
 }
@@ -887,6 +886,7 @@ static inline long make_square_free_elim_poly(param_t *param,
     for(ulong i = 0; i < data_bms->sqf->num; i++){
       nmod_poly_mul(param->elim, param->elim, data_bms->sqf->p+i);
     }
+    param->degsqfrelimpol = param->elim->length-1;
     /* JB to change */
     /* if(info_level){ */
     /*   fprintf(stderr, "Degree of the square-free part: %ld\n", */
@@ -1755,8 +1755,9 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   exit(1);
 #else
   if (info_level > 1) {
-    fprintf (stdout,
-	     "Krylov sequence                                     ");
+    fprintf(stdout,
+	    "Krylov sequence                                     ");
+    fflush(stdout);
   }
   generate_sequence_verif(matrix, *bdata, block_size, dimquot,
                           squvars, linvars, nvars, prime, st);
@@ -1773,8 +1774,9 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   st_fglm = realtime();
   cst_fglm = cputime();
   if (info_level > 1) {
-    fprintf (stdout,
-	     "elimination polynomial                              ");
+    fprintf(stdout,
+	    "elimination polynomial                              ");
+    fflush(stdout);
   }
 
   /* Berlekamp-Massey data */
@@ -1803,8 +1805,9 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
     st_fglm = realtime();
     cst_fglm = cputime();
     if (info_level > 1){
-      fprintf (stdout,
-	       "parametrizations                                    ");
+      fprintf(stdout,
+	      "parametrizations                                    ");
+      fflush(stdout);
     }
       
     if(compute_parametrizations(param, *bdata, *bdata_bms,

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -70,6 +70,37 @@ double omp_get_wtime(void) { return realtime();}
 #include "../upolmat/nmod_poly_mat_pmbasis.c"
 #endif
 
+void print_fglm_data(
+        FILE *file,
+        const md_t * const st,
+	sp_matfglm_t *matrix,
+	param_t *param
+		     )
+{
+  if (st->info_level > 0) {
+    fprintf(file, "\n---------------- TIMINGS ----------------\n");
+    fprintf(file, "overall(elapsed) %11.2f sec\n", st->fglm_rtime);
+    fprintf(file, "overall(cpu) %15.2f sec\n", st->fglm_ctime);
+    fprintf(file, "-----------------------------------------\n");
+    fprintf(file, "\n---------- COMPUTATIONAL DATA -----------\n");
+    fprintf(file, "degree of ideal    %16lu\n", (unsigned long)matrix->ncols);
+    fprintf(file, "#dense rows        %16lu\n", (unsigned long)matrix->nrows);
+    if(matrix->nnfs){
+      fprintf(file, "#normal forms      %16lu\n", (unsigned long)matrix->nnfs);
+    }
+    fprintf(file, "total density                    %3.2f%%\n", 100*matrix->totaldensity);
+    fprintf(file, "density of the free part         %3.2f%%\n", 100*matrix->freepartdensity);
+    if(matrix->nnfs){
+      fprintf(file, "density of the nonfree part      %3.2f%%\n", 100*matrix->nonfreepartdensity);
+    }
+    fprintf(file, "deg. elim. pol.    %16lu\n", (unsigned long)param->degelimpol);
+    fprintf(file, "deg. sqfr. elim. pol. %13lu\n", (unsigned long)(param->elim->length-1));
+    fprintf(file, "-----------------------------------------\n\n");
+  }
+}
+
+
+
 void display_nmod_poly(FILE *file, nmod_poly_t pol){
   fprintf(file, "[%ld,\n", pol->length-1);
   if(pol->length != 0){
@@ -833,6 +864,7 @@ static inline long make_square_free_elim_poly(param_t *param,
                                               long dimquot,
                                               int info_level){
   long dim = data_bms->BMS->V1->length - 1;
+  param->degelimpol = dim;
   
   int boo = nmod_poly_is_squarefree(data_bms->BMS->V1);
 
@@ -843,9 +875,10 @@ static inline long make_square_free_elim_poly(param_t *param,
   else{
 
     if(boo==0){
-      if(info_level){
-        fprintf(stderr, "Mininimal polynomial is not square-free\n");
-      }
+      /* JB to change */
+      /* if(info_level){ */
+      /*   fprintf(stderr, "Minimal polynomial is not square-free\n"); */
+      /* } */
     }
 
     nmod_poly_factor_squarefree(data_bms->sqf, data_bms->BMS->V1);
@@ -854,11 +887,12 @@ static inline long make_square_free_elim_poly(param_t *param,
     for(ulong i = 0; i < data_bms->sqf->num; i++){
       nmod_poly_mul(param->elim, param->elim, data_bms->sqf->p+i);
     }
-    if(info_level){
-      fprintf(stderr, "Degree of the square-free part: %ld\n",
-              param->elim->length-1);
-      fprintf(stderr, "[%ld, %ld, %ld]\n", dimquot, dim, param->elim->length - 1);
-    }
+    /* JB to change */
+    /* if(info_level){ */
+    /*   fprintf(stderr, "Degree of the square-free part: %ld\n", */
+    /*           param->elim->length-1); */
+    /*   fprintf(stderr, "[%ld, %ld, %ld]\n", dimquot, dim, param->elim->length - 1); */
+    /* } */
   }
 
   data_bms->sqf->num=0;
@@ -877,19 +911,21 @@ static inline long make_square_free_elim_poly_colon(param_t *param,
     nmod_poly_set(param->elim, data_bms->BMS->V1);
   }
   else{
-    if(info_level){
-      fprintf(stderr, "Mininimal polynomial is not square-free\n");
-    }
+    /* JB to change */
+    /* if(info_level){ */
+    /*   fprintf(stderr, "Minimal polynomial is not square-free\n"); */
+    /* } */
     nmod_poly_factor_squarefree(data_bms->sqf, data_bms->BMS->V1);
     nmod_poly_one(param->elim);
     for(ulong i = 0; i < data_bms->sqf->num; i++){
       nmod_poly_mul(param->elim, param->elim, data_bms->sqf->p+i);
     }
-    if(info_level){
-      fprintf(stderr, "Degree of the square-free part: %ld\n",
-              param->elim->length-1);
-      fprintf(stderr, "[%ld, %ld, %ld]\n", dimquot, dim, param->elim->length - 1);
-    }
+    /* JB to change */
+    /* if(info_level){ */
+    /*   fprintf(stderr, "Degree of the square-free part: %ld\n", */
+    /*           param->elim->length-1); */
+    /*   fprintf(stderr, "[%ld, %ld, %ld]\n", dimquot, dim, param->elim->length - 1); */
+    /* } */
   }
 
   data_bms->sqf->num=0;
@@ -1693,17 +1729,19 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   szmat_t sz = matrix->ncols * matrix->nrows;
   szmat_t nb = initialize_fglm_data(matrix, *bdata, prime, sz, block_size);
 
-  if(info_level){
-    fprintf(stderr, "[%u, %u], Dense / Total = %.2f%%\n",
-            matrix->ncols, matrix->nrows,
-            100*((double)matrix->nrows / (double)matrix->ncols));
-    fprintf(stderr, "Density of non-trivial part %.2f%%\n",
-            100-100*(float)nb/(float)sz);
-  }
+  /* JB to change */
+  /* if(info_level){ */
+  /*   fprintf(stderr, "[%u, %u], Dense / Total = %.2f%%\n", */
+  /*           matrix->ncols, matrix->nrows, */
+  /*           100*((double)matrix->nrows / (double)matrix->ncols)); */
+  /*   fprintf(stderr, "Density of non-trivial part %.2f%%\n", */
+  /*           100-100*(float)nb/(float)sz); */
+  /* } */
 
   szmat_t dimquot = (matrix->ncols);
 
   double st_fglm = realtime();
+  double cst_fglm = cputime();
 
 #if BLOCKWIED > 0
   fprintf(stderr, "Starts computation of matrix sequence\n");
@@ -1716,17 +1754,28 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   fprintf(stderr, "Implementation to be completed\n");
   exit(1);
 #else
+  if (info_level > 1) {
+    fprintf (stdout,
+	     "Krylov sequence                                     ");
+  }
   generate_sequence_verif(matrix, *bdata, block_size, dimquot,
                           squvars, linvars, nvars, prime, st);
 #endif
 
-  if(info_level){
+  if(info_level > 1){
     double nops = 2 * (matrix->nrows/ 1000.0) * (matrix->ncols / 1000.0)  * (matrix->ncols / 1000.0);
     double rt_fglm = realtime()-st_fglm;
-    fprintf(stderr, "Time spent to generate sequence (elapsed): %.2f sec (%.2f Gops/sec)\n", rt_fglm, nops / rt_fglm);
+    double crt_fglm = cputime()-cst_fglm;
+    /* fprintf(stderr, "Time spent to generate sequence (elapsed): %.2f sec (%.2f Gops/sec)\n", rt_fglm, nops / rt_fglm); */
+    fprintf (stdout, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
   }
 
   st_fglm = realtime();
+  cst_fglm = cputime();
+  if (info_level > 1) {
+    fprintf (stdout,
+	     "elimination polynomial                              ");
+  }
 
   /* Berlekamp-Massey data */
   *bdata_bms = allocate_fglm_bms_data(dimquot, prime);
@@ -1735,18 +1784,29 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   compute_minpoly(param, *bdata, *bdata_bms, dimquot, linvars, lineqs,
                   nvars, &dim, info_level);
 
-  if(info_level){
-    fprintf(stderr, "Time spent to compute eliminating polynomial (elapsed): %.2f sec\n",
-            realtime()-st_fglm);
+  if(info_level > 1){
+    /* fprintf(stderr, "Time spent to compute eliminating polynomial (elapsed): %.2f sec\n", */
+    /*         realtime()-st_fglm); */
+    double rt_fglm = realtime()-st_fglm;
+    double crt_fglm = cputime()-cst_fglm;
+    fprintf (stdout, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
   }
 
 
   if (dimquot == dim) {
 
-    if(info_level){
-      fprintf(stderr, "Elimination polynomial has degree %d.\n", dimquot);
+    /* JB to change */
+    /* if(info_level){ */
+    /*   fprintf(stderr, "Elimination polynomial has degree %d.\n", dimquot); */
+    /* } */
+    
+    st_fglm = realtime();
+    cst_fglm = cputime();
+    if (info_level > 1){
+      fprintf (stdout,
+	       "parametrizations                                    ");
     }
-
+      
     if(compute_parametrizations(param, *bdata, *bdata_bms,
                                 dim, dimquot, block_size,
                                 nlins, linvars, lineqs,
@@ -1756,14 +1816,26 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
       return NULL;
 
     }
-
+    if (info_level > 1){
+      double rt_fglm = realtime()-st_fglm;
+      double crt_fglm = cputime()-cst_fglm;
+      fprintf(stdout, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
+      fprintf(stdout,
+	      "-------------------------------------------------\
+-----------------------------------------------------\n");
+    }
   }
   else {
     /* computes the param of the radical */
-    if(info_level){
-      fprintf(stderr, "Elimination polynomial is not squarefree.\n");
-    }
+    /* if(info_level){ */
+    /*   fprintf(stderr, "Elimination polynomial is not squarefree.\n"); */
+    /* } */
 
+    st_fglm = realtime();
+    if (info_level > 1){
+      fprintf (stdout,
+	       "parametrizations                                               ");
+    }
     int right_param= compute_parametrizations_non_shape_position_case(param,
                                                                       *bdata,
                                                                       *bdata_bms,
@@ -1775,6 +1847,13 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
                                                                       nvars, prime,
                                                                       1); /* verif */
 
+    if (info_level > 1){
+      double rt_fglm = realtime()-st_fglm;
+      fprintf(stdout, "%.2f\n",rt_fglm);
+      fprintf(stdout,
+	      "-------------------------------------------------\
+-----------------------------------------------------\n");
+    }
     if (right_param == 0) {
       if(info_level){
         fprintf(stderr, "Matrix is not invertible (there should be a bug)\n");
@@ -1799,6 +1878,9 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
             *success = 0;
           }
   }
+  st->fglm_rtime = realtime() - st->fglm_rtime;
+  st->fglm_ctime = cputime() - st->fglm_ctime;
+  print_fglm_data (stdout, st, matrix, param);
   return param;
 }
 

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -92,7 +92,6 @@ void print_fglm_data(
       fprintf(file, "density of the nonfree part     %5.1f%%\n", 100*matrix->nonfreepartdensity);
     }
     fprintf(file, "deg. elim. pol.    %16lu\n", (unsigned long)param->degelimpol);
-
     fprintf(file, "deg. sqfr. elim. pol. %13lu\n", (unsigned long)param->degsqfrelimpol);
     fprintf(file, "-----------------------------------------\n\n");
   }
@@ -870,6 +869,7 @@ static inline long make_square_free_elim_poly(param_t *param,
   if(boo && dim == dimquot){
     nmod_poly_set(param->elim, data_bms->BMS->V1);
     nmod_poly_one(param->denom);
+    param->degsqfrelimpol = dim;
   }
   else{
 

--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -23,6 +23,20 @@
 #include "../neogb/meta_data.h"
 #define REDUCTION_ALLINONE 1
 
+void print_fglm_header(
+        FILE *f,
+        const md_t * const st
+        )
+{
+    if (st->info_level > 1) {
+            fprintf(f, "\nstep                                           \
+          time(rd) in sec (real|cpu)\n");
+            fprintf(f, "-------------------------------------------------\
+-----------------------------------------------------\n");
+    }
+}
+
+
 static void (*copy_poly_in_matrix_from_bs)(sp_matfglm_t* matrix,
                                            long nrows,
                                            bs_t *bs,
@@ -3246,11 +3260,12 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
   if (count_not_lm) {
     free_basis_without_hash_table(&tbr);
   }
-  if(st->info_level){
-    fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n",
-            len0, len_xn,
-            100*((double)len_xn / (double)len0));
-  }
+  /* JB to change */
+  /* if(st->info_level){ */
+  /*   fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n", */
+  /*           len0, len_xn, */
+  /*           100*((double)len_xn / (double)len0)); */
+  /* } */
 }
 
 
@@ -3469,6 +3484,8 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 								  const long fc,
 								  const int32_t unstable_staircase,
 								  const int info_level){
+  double st_fglm = realtime();
+  double cst_fglm = cputime();
   *bdiv_xn = calloc((unsigned long)bs->lml, sizeof(int32_t));
   int32_t *div_xn = *bdiv_xn;
   long len_xn = get_div_xn(bexp_lm, bs->lml, nv, div_xn);
@@ -3644,6 +3661,9 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
       tbr->lmps[k]  = k; /* fix input element in bs */
     }
     int32_t err = 0;
+    if (md->info_level > 1) {
+      fprintf (stdout, "normal forms\n");
+    }
     tbr = core_nf(tbr, md, mul, bs, &err);
     if (err) {
       printf("Problem with normalform, stopped computation.\n");
@@ -3712,6 +3732,9 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   long count = 0;
   long count_nf = 0;
 
+  long nzcfs_freepart = 0;
+  long nzcfs_nonfreepart = 0;
+
   for(long i = 0; i < dquot; i++){
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
@@ -3743,6 +3766,11 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
                                     div_xn[count], len_gb_xn[count],
                                     start_cf_gb_xn[count], len_gb_xn[count], lmb,
                                     nv, fc);
+	for (long j = 0; j < dquot; j++) {
+	  if (matrix->dense_mat[nrows*matrix->ncols + j] != 0) {
+	    nzcfs_freepart++;
+	  }
+	}
         nrows++;
         count++;
         if(len_xn < count && i < dquot){
@@ -3774,6 +3802,11 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 #endif
 	copy_nf_in_matrix_from_bs(matrix, nrows, count_nf, lmb,
 				  tbr, ht, evi, st, nv);
+	for (long j = 0; j < dquot; j++) {
+	  if (matrix->dense_mat[nrows*matrix->ncols + j] != 0) {
+	    nzcfs_nonfreepart++;
+	  }
+	}
 	nrows++;
 	count_nf++;
         if(count_not_lm < count_nf && i < dquot){
@@ -3833,14 +3866,33 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
       }
     }
   }
-
   if (count_not_lm) {
+    matrix->nonfreepartdensity = ((double)nzcfs_nonfreepart) / ((double)dquot * count_not_lm);
     free_basis_without_hash_table(&tbr);
   }
-  if(st->info_level){
-    fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n",
-            len0, len_xn,
-            100*((double)len_xn / (double)len0));
+  matrix->freepartdensity = ((double)nzcfs_freepart) / ((double)dquot * len_xn);
+  matrix->totaldensity = ((double)nzcfs_nonfreepart + nzcfs_freepart)/((double) len1);
+
+  /* JB to change */
+  /* if(st->info_level){ */
+  /*   fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n", */
+  /*           len0, len_xn, */
+  /*           100*((double)len_xn / (double)len0)); */
+  /*   fprintf (stderr, "total density: %.2f%%\n", */
+  /* 	     100 * matrix->totaldensity); */
+  /*   fprintf (stderr, "density of the free part: %.2f%%\n", */
+  /* 	     100 * matrix->freepartdensity); */
+  /*   if (count_not_lm) { */
+  /*     fprintf (stderr, "density of the nonfree part: %.2f%%\n", */
+  /* 	       100 * matrix->nonfreepartdensity); */
+  /*   } */
+  /* } */
+  if (st->info_level > 1){
+    double rt_fglm = realtime()-st_fglm;
+    double crt_fglm = cputime()-cst_fglm;
+    fprintf (stdout,
+	     "multiplication matrix                               ");
+    fprintf (stdout,"%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
   }
   return matrix;
 }

--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -3661,7 +3661,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
       tbr->lmps[k]  = k; /* fix input element in bs */
     }
     int32_t err = 0;
-    if (md->info_level > 1) {
+    if (st->info_level > 1) {
       fprintf (stdout, "normal forms\n");
     }
     tbr = core_nf(tbr, md, mul, bs, &err);
@@ -3873,20 +3873,6 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   matrix->freepartdensity = ((double)nzcfs_freepart) / ((double)dquot * len_xn);
   matrix->totaldensity = ((double)nzcfs_nonfreepart + nzcfs_freepart)/((double) len1);
 
-  /* JB to change */
-  /* if(st->info_level){ */
-  /*   fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n", */
-  /*           len0, len_xn, */
-  /*           100*((double)len_xn / (double)len0)); */
-  /*   fprintf (stderr, "total density: %.2f%%\n", */
-  /* 	     100 * matrix->totaldensity); */
-  /*   fprintf (stderr, "density of the free part: %.2f%%\n", */
-  /* 	     100 * matrix->freepartdensity); */
-  /*   if (count_not_lm) { */
-  /*     fprintf (stderr, "density of the nonfree part: %.2f%%\n", */
-  /* 	       100 * matrix->nonfreepartdensity); */
-  /*   } */
-  /* } */
   if (st->info_level > 1){
     double rt_fglm = realtime()-st_fglm;
     double crt_fglm = cputime()-cst_fglm;

--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -29,7 +29,7 @@ void print_fglm_header(
         )
 {
     if (st->info_level > 1) {
-            fprintf(f, "\nstep                                           \
+            fprintf(f, "\nfglm steps                                     \
           time(rd) in sec (real|cpu)\n");
             fprintf(f, "-------------------------------------------------\
 -----------------------------------------------------\n");
@@ -3139,7 +3139,7 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
   long nrows = 0;
   long count = 0;
   long count_nf = 0;
-  
+
   for(long i = 0; i < dquot; i++){
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
@@ -3260,7 +3260,6 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
   if (count_not_lm) {
     free_basis_without_hash_table(&tbr);
   }
-  /* JB to change */
   /* if(st->info_level){ */
   /*   fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n", */
   /*           len0, len_xn, */
@@ -3587,7 +3586,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 #endif
 
   long threshold = dquot-len_xn;
-  
+
   switch(unstable_staircase) {
   case 0:
     threshold = 0;
@@ -3602,7 +3601,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     threshold = (3*threshold+1)/4; /* round to nearest integer */
     break;
   }
-  
+
   if (count_not_lm > threshold) {
     if(info_level){
       fprintf(stderr, "Staircase is not generic\n");

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1326,16 +1326,29 @@ int msolve_gbtrace_qq(
       dlinit = 1;
     }
 
+    /* if(info_level){ */
+    /*   int s= 0; */
+    /*   for(int i = 0; i < dlift->nsteps; i++){ */
+    /*     fprintf(stderr, "[%d]", dlift->steps[i]); */
+    /*     s+=dlift->steps[i]; */
+    /*   } */
+    /*   fprintf(stderr, "\n"); */
+    /*   if(s > 1){ */
+    /*     fprintf(stderr, "%d polynomials to lift\n", s); */
+    /*   } */
+    /* } */
     if(info_level){
+      fprintf(stdout,"\n\n---------- COMPUTATIONAL DATA -----------\n");
       int s= 0;
       for(int i = 0; i < dlift->nsteps; i++){
-        fprintf(stderr, "[%d]", dlift->steps[i]);
+        fprintf(stdout, "[%d]", dlift->steps[i]);
         s+=dlift->steps[i];
       }
-      fprintf(stderr, "\n");
-      if(s > 1){
-        fprintf(stderr, "%d polynomials to lift\n", s);
-      }
+      fprintf(stdout, "\n");
+      fprintf(stdout,
+	      "#polynomials to lift %14lu\n",
+	      (unsigned long) s);
+      fprintf(stdout, "-----------------------------------------\n");
     }
 
     if(lmb_ori == NULL || success == 0 || gens->field_char) {
@@ -1368,9 +1381,10 @@ int msolve_gbtrace_qq(
       msd->blht[i] = lht;
     }
 
-    if(info_level){
-      fprintf(stderr, "\nStarts multi-modular computations\n");
-    }
+    /* if(info_level){ */
+    /*   fprintf(stderr, "\nStarts multi-modular computations\n"); */
+    /* } */
+    /* print postponed */
 
     learn = 0;
     while(apply){
@@ -1430,11 +1444,32 @@ int msolve_gbtrace_qq(
           fprintf(stderr, "#REDUCTIONS      %13lu\n", (unsigned long)st->application_nr_red);
           fprintf(stderr, "------------------------------------------\n");
         }
-        if(info_level>1){
-          fprintf(stderr, "Application phase %.2f Gops/sec\n",
-                  (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
-          fprintf(stderr, "Elapsed time: %.2f\n", stf4);
-        }
+        /* if(info_level>1){ */
+        /*   fprintf(stderr, "Application phase %.2f Gops/sec\n", */
+        /*           (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4)); */
+        /*   fprintf(stderr, "Elapsed time: %.2f\n", stf4); */
+        /* } */
+	if(info_level){
+	  fprintf(stdout,
+		  "\n---------------- TIMINGS ----------------\n");
+	  fprintf(stdout,
+		  "multi-mod overall(elapsed) %9.2f sec\n",
+		  stf4);
+	  if (info_level > 1){
+	    fprintf(stdout,
+		    "application phase     %9.2f Gops/sec\n",
+		    (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
+	  }
+	  fprintf(stdout,
+		  "-----------------------------------------\n");
+      }
+      if (info_level) {
+	  fprintf(stdout,
+		  "\nmulti-modular steps\n");
+	  fprintf(stdout, "-------------------------------------------------\
+-----------------------------------------------------\n");
+      }
+
       }
       int bad = 0;
       for(int i = 0; i < nthrds/* st->nthrds */; i++){
@@ -1470,12 +1505,12 @@ int msolve_gbtrace_qq(
       if((st_crt -ost_crt) + (st_rrec - ost_rrec) > dlift->rr * stf4){
         dlift->rr = 2*dlift->rr;
         if(info_level){
-          fprintf(stderr, "(->%d)", dlift->rr);
+          fprintf(stdout, "(->%d)", dlift->rr);
         }
       }
       if(info_level){
         if(!(nprimes & (nprimes - 1))){
-          fprintf(stderr, "{%d}", nprimes);
+          fprintf(stdout, "{%d}", nprimes);
         }
       }
       apply = 0;
@@ -1487,21 +1522,35 @@ int msolve_gbtrace_qq(
       }
       if(dlift->lstart != lstart){
         if(info_level){
-          fprintf(stderr, "<%.2f%%>", 100* (float)MIN((dlift->lstart + 1), modgbs->ld)/modgbs->ld);
+          fprintf(stdout, "<%.2f%%>", 100* (float)MIN((dlift->lstart + 1), modgbs->ld)/modgbs->ld);
         }
         lstart = dlift->lstart;
       }
       /* this is where learn could be reset to 1 */
       /* but then duplicated datas and others should be free-ed */
     }
+    if (info_level){
+      fprintf(stdout, " \n-------------------------------------------------\
+-----------------------------------------------------\n");
+    }
   }
-  if(info_level){
-    fprintf(stderr, "\nCRT time = %.2f, Rational reconstruction time = %.2f\n", st_crt, st_rrec);
-  }
+  /* if(info_level){ */
+  /*   fprintf(stderr, "\nCRT time = %.2f, Rational reconstruction time = %.2f\n", st_crt, st_rrec); */
+  /* } */
   if(info_level){
     long nbits = max_bit_size_gb(modgbs);
-    fprintf(stderr, "Maximum bit size of the coefficients: %ld\n", nbits);
-    fprintf(stderr, "%d primes used. \nElapsed time: %.2f\n", nprimes, realtime()-st0);
+    /* fprintf(stderr, "Maximum bit size of the coefficients: %ld\n", nbits); */
+    /* fprintf(stderr, "%d primes used. \nElapsed time: %.2f\n", nprimes, realtime()-st0); */
+    fprintf(stdout,"\n\n---------- COMPUTATIONAL DATA -----------\n");
+    fprintf(stdout, "Max coeff. bitsize %16lu\n", (unsigned long) nbits);
+    fprintf(stdout, "#primes            %16lu\n", (unsigned long) nprimes);
+    fprintf(stdout, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
+    fprintf(stdout, "-----------------------------------------\n");
+    fprintf(stdout, "\n---------------- TIMINGS ----------------\n");
+    fprintf(stdout, "CRT     (elapsed)         %10.2f sec\n", st_crt);
+    fprintf(stdout, "ratrecon(elapsed)         %10.2f sec\n", st_rrec);
+    /* fprintf(stdout, "CRT and ratrecon(elapsed) %10.2f sec\n", realtime()-st0); */
+    fprintf(stdout, "-----------------------------------------\n");
   }
   free_mstrace(msd, st);
   if(dlinit){

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1457,7 +1457,7 @@ int msolve_gbtrace_qq(
 		  stf4);
 	  if (info_level > 1){
 	    fprintf(stdout,
-		    "application phase     %9.2f Gops/sec\n",
+		    "application phase          %9.2f Gops/sec\n",
 		    (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
 	  }
 	  fprintf(stdout,

--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -409,7 +409,7 @@ int main(int argc, char **argv){
       fclose(ofile);
     }
     /**
-       We get from files the requested data. 
+       We get from files the requested data.
     **/
     //  int32_t mon_order   = 0;
     int32_t nr_vars     = 0;
@@ -433,7 +433,7 @@ int main(int argc, char **argv){
         }
         la_option = 2;
     }
-    
+
     /* data structures for parametrization */
     param_t *param  = NULL;
     mpz_param_t *mpz_paramp = malloc(sizeof(mpz_param_t));
@@ -469,7 +469,7 @@ int main(int argc, char **argv){
     if (info_level > 0) {
         double st1 = cputime();
         double rt1 = realtime();
-        fprintf(stderr, "-------------------------------------------------\
+        fprintf(stderr, "\n-------------------------------------------------\
 -----------------------------------\n");
         fprintf(stderr, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
                 rt1-rt0, st1-st0);

--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -469,7 +469,7 @@ int main(int argc, char **argv){
     if (info_level > 0) {
         double st1 = cputime();
         double rt1 = realtime();
-        fprintf(stderr, "\n-------------------------------------------------\
+        fprintf(stderr, "\n\n-------------------------------------------------\
 -----------------------------------\n");
         fprintf(stderr, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
                 rt1-rt0, st1-st0);

--- a/src/msolve/msolve-data.h
+++ b/src/msolve/msolve-data.h
@@ -116,6 +116,9 @@ typedef struct{
   szmat_t *dense_idx; //position des lignes non triviales (qui constituent donc
                       //dense_mat)
   szmat_t *dst; //pour la gestion des lignes "denses" mais avec un bloc de zero a la fin
+  double totaldensity;
+  double freepartdensity;
+  double nonfreepartdensity;
 } sp_matfglm_t;
 
 #ifndef ALIGNED32
@@ -164,6 +167,7 @@ typedef struct{
   nmod_poly_t elim;
   nmod_poly_t denom;
   nmod_poly_t *coords;
+  szmat_t degelimpol;
 } param_t;
 
 

--- a/src/msolve/msolve-data.h
+++ b/src/msolve/msolve-data.h
@@ -168,6 +168,7 @@ typedef struct{
   nmod_poly_t denom;
   nmod_poly_t *coords;
   szmat_t degelimpol;
+  szmat_t degsqfrelimpol;
 } param_t;
 
 

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1673,14 +1673,14 @@ static void secondary_modular_steps(sp_matfglm_t **bmatrix,
 				    nvars_t **blinvars,
 				    uint32_t **blineqs,
 				    nvars_t **bsquvars,
-				    
+
 				    fglm_data_t **bdata_fglm,
 				    fglm_bms_data_t **bdata_bms,
-				    
+
 				    int32_t *num_gb,
 				    int32_t **leadmons_ori,
 				    int32_t **leadmons_current,
-				    
+
 				    uint64_t bsz,
 				    param_t **nmod_params,
 				    /* trace_t **btrace, */
@@ -2052,7 +2052,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
   nvars_t **bsquvars = (nvars_t **)malloc(st->nthrds * sizeof(nvars_t *));
   nvars_t *squvars = calloc(nr_vars - 1, sizeof(nvars_t));
   bsquvars[0] = squvars;
-  
+
 
   set_linear_function_pointer(gens->field_char);
 
@@ -2068,11 +2068,11 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 
 					  &nlins, blinvars[0], lineqs_ptr,
 					  squvars,
-					  
+
 					  bdata_fglm, bdata_bms,
-					  
+
 					  num_gb, leadmons_ori,
-					  
+
 					  &bsz, nmod_params,
 					  bs_qq, st,
 					  lp->p[0], //prime,
@@ -2342,20 +2342,33 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
                 (unsigned long)st->application_nr_red);
         fprintf(stderr, "------------------------------------------\n");
       }
-      if (info_level > 1) {
-        fprintf(stderr, "Application phase %.2f Gops/sec\n",
-                (st->application_nr_add + st->application_nr_mult) / 1000.0 /
-                    1000.0 / (stf4));
-	/* JB to change */
-        /* fprintf(stderr, "Multi-mod time: GB + fglm (elapsed): %.2f sec\n", */
-        /*         (ca1) ); */
-      }
+      /* JB to change */
+      /* if (info_level > 1) { */
+      /*   fprintf(stderr, "Application phase %.2f Gops/sec\n", */
+      /*           (st->application_nr_add + st->application_nr_mult) / 1000.0 / */
+      /*               1000.0 / (stf4)); */
+      /*   fprintf(stderr, "Multi-mod time: GB + fglm (elapsed): %.2f sec\n", */
+      /*           (ca1) ); */
+      /* } */
       if(info_level){
-	    fprintf(stdout, "\n---------------- TIMINGS ----------------\n");
-	    fprintf(stdout, "multi-mod overall(elapsed) %9.2f sec\n", ca1);
-	    fprintf(stdout, "multi-mod F4               %9.2f sec\n", stf4);
-	    fprintf(stdout, "multi-mod FGLM             %9.2f sec\n", ca1-stf4);
-	    fprintf(stdout, "-----------------------------------------\n\n");
+	    fprintf(stdout,
+		    "\n---------------- TIMINGS ----------------\n");
+	    fprintf(stdout,
+		    "multi-mod overall(elapsed) %9.2f sec\n",
+		    ca1);
+	    fprintf(stdout,
+		    "multi-mod F4               %9.2f sec\n",
+		    stf4);
+	    fprintf(stdout,
+		    "multi-mod FGLM             %9.2f sec\n",
+		    ca1-stf4);
+	    if (info_level > 1){
+	      fprintf(stdout,
+		      "application phase     %9.2f Gops/sec\n",
+		      (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
+	    }
+	    fprintf(stdout,
+		    "-----------------------------------------\n");
       }
     }
     for (int i = 0; i < st->nthrds; i++) {
@@ -2446,10 +2459,13 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 
 
   if(info_level){
-    /* JB to change */
     /* fprintf(stderr, "\n%d primes used\n", nprimes); */
     /* fprintf(stderr, "Time for CRT + rational reconstruction = %.2f\n", strat); */
-    fprintf(stdout, "\n\n---------------- TIMINGS ----------------\n");
+    fprintf(stdout,"\n\n---------- COMPUTATIONAL DATA -----------\n");
+    fprintf(stdout, "#primes            %16lu\n", (unsigned long) nprimes);
+    fprintf(stdout, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
+    fprintf(stdout, "-----------------------------------------\n");
+    fprintf(stdout, "\n---------------- TIMINGS ----------------\n");
     fprintf(stdout, "CRT and ratrecon(elapsed) %10.2f sec\n", st->fglm_rtime);
     fprintf(stdout, "-----------------------------------------\n");
   }
@@ -3306,9 +3322,14 @@ int real_msolve_qq(mpz_param_t *mpz_paramp, param_t **nmod_param, int *dim_ptr,
     /*     rt1 - rt0, ct1 - ct0); */
     fprintf (stdout,
 	     "\n---------------- TIMINGS ----------------\n");
-    fprintf(stdout, "rational param(elapsed) %12.2f sec\n", rt1-rt0);
-    fprintf(stdout, "rational param(cpu) %16.2f sec\n", ct1-ct0);
-    fprintf(stdout, "-----------------------------------------\n");
+    fprintf(stdout,
+	    "rational param(elapsed) %12.2f sec\n",
+	    rt1-rt0);
+    fprintf(stdout,
+	    "rational param(cpu) %16.2f sec\n",
+	    ct1-ct0);
+    fprintf(stdout,
+	    "-----------------------------------------\n");
   }
 
   if (get_param > 1) {
@@ -3812,18 +3833,18 @@ restart:
 	    long suppsize= tbr->hm[tbr->lmps[1]][LENGTH]; // bs->hm[bs->lmps[1]][LENGTH]
 	    printf("Length of the support of phi: %lu\n",
 		   suppsize);
-	    
+
 	    /* sht and hcm will store the support of the normal form in tbr. */
 	    ht_t *sht   = initialize_secondary_hash_table(bht, st);
 	    hi_t *hcm   = (hi_t *)malloc(sizeof(hi_t));
 	    mat_t *mat  = (mat_t *)calloc(1, sizeof(mat_t));
-	    
+
 	    /* printf("Starts computation of normal form matrix\n"); */
 	    get_normal_form_matrix(tbr, bht, 1,
 				   st, &sht, &hcm, &mat);
 	    printf("Length of union of support of all normal forms: %u\n",
 		   mat->nc);
-	    
+
 	    /* printf("\nUnion of support, sorted by decreasing monomial order:\n"); */
 	    /* for (len_t k = 0; k < mat->nc; ++k) { */
 	    /*   for (len_t l = 1; l <= sht->nv; ++l) { */
@@ -3834,7 +3855,7 @@ restart:
 
 	    int32_t *bcf_ff = (int32_t *)(*bcf);
 	    int32_t *bexp_lm = get_lead_monomials(bld, blen, bexp, gens);
-	    
+
 	    long maxdeg = sht->ev[hcm[0]][0]; /* degree of the normal
 						 form */
 	    for (long i = 0; i < bld[0]; i++) {
@@ -3959,7 +3980,7 @@ restart:
 	    if (sht != NULL) {
 	      free_hash_table(&sht);
 	    }
-	    
+
             /* free and clean up */
             if (bs != NULL) {
 	      free_basis(&bs);
@@ -4089,7 +4110,7 @@ restart:
             fprintf(stderr, "This will\n");
             fprintf(stderr, "be done automatically if you run msolve with option\n");
             fprintf(stderr, "\"-c2\" which is the default.\n");
-	  } 
+	  }
         }
 	else {
           /* normal_form is 1 */
@@ -4273,7 +4294,7 @@ restart:
                     &gens->nvars, &gens->ngens, &saturate, &initial_hts,
                     &nr_threads, &max_pairs, &update_ht, &la_option,
                     &use_signatures, &reduce_gb, &info_level);
-	    
+
             /* all data is corrupt */
             if (res == -1) {
                 fprintf(stderr, "Invalid input generators, msolve now terminates.\n");

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1630,6 +1630,9 @@ static int32_t *initial_modular_step(
 	      *success = 0;
 	      *dim = 0;
 	      *dquot_ori = dquot;
+	      if(md->info_level > 1){
+		fprintf (stdout,"------------------------------------------------------------------------------------------------------\n");
+	      }
 	      return NULL;
             }
 
@@ -2298,7 +2301,6 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
     prime = lp->p[st->nthrds - 1];
 
     double ca0 = realtime();
-
     double stf4 = 0;
     secondary_modular_steps(bmatrix,
 			    bdiv_xn,
@@ -2344,8 +2346,16 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
         fprintf(stderr, "Application phase %.2f Gops/sec\n",
                 (st->application_nr_add + st->application_nr_mult) / 1000.0 /
                     1000.0 / (stf4));
-        fprintf(stderr, "Multi-mod time: GB + fglm (elapsed): %.2f sec\n",
-                (ca1));
+	/* JB to change */
+        /* fprintf(stderr, "Multi-mod time: GB + fglm (elapsed): %.2f sec\n", */
+        /*         (ca1) ); */
+      }
+      if(info_level){
+	    fprintf(stdout, "\n---------------- TIMINGS ----------------\n");
+	    fprintf(stdout, "multi-mod overall(elapsed) %9.2f sec\n", ca1);
+	    fprintf(stdout, "multi-mod F4               %9.2f sec\n", stf4);
+	    fprintf(stdout, "multi-mod FGLM             %9.2f sec\n", ca1-stf4);
+	    fprintf(stdout, "-----------------------------------------\n\n");
       }
     }
     for (int i = 0; i < st->nthrds; i++) {
@@ -2434,9 +2444,14 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
                (*mpz_paramp)->denom->coeffs[i - 1], i);
   }
 
-  if (info_level) {
-    fprintf(stderr, "\n%d primes used\n", nprimes);
-    fprintf(stderr, "Time for CRT + rational reconstruction = %.2f\n", strat);
+
+  if(info_level){
+    /* JB to change */
+    /* fprintf(stderr, "\n%d primes used\n", nprimes); */
+    /* fprintf(stderr, "Time for CRT + rational reconstruction = %.2f\n", strat); */
+    fprintf(stdout, "\n\n---------------- TIMINGS ----------------\n");
+    fprintf(stdout, "CRT and ratrecon(elapsed) %10.2f sec\n", st->fglm_rtime);
+    fprintf(stdout, "-----------------------------------------\n");
   }
   mpz_param_clear(tmp_mpz_param);
   mpz_upoly_clear(numer);
@@ -3283,11 +3298,17 @@ int real_msolve_qq(mpz_param_t *mpz_paramp, param_t **nmod_param, int *dim_ptr,
   double ct1 = cputime();
   double rt1 = realtime();
 
-  if (info_level && print_gb == 0) {
-    fprintf(
-        stderr,
-        "Time for rational param: %13.2f (elapsed) sec / %5.2f sec (cpu)\n\n",
-        rt1 - rt0, ct1 - ct0);
+  if(info_level && print_gb == 0){
+    /* JB to change */
+    /* fprintf( */
+    /*     stderr, */
+    /*     "Time for rational param: %13.2f (elapsed) sec / %5.2f sec (cpu)\n\n", */
+    /*     rt1 - rt0, ct1 - ct0); */
+    fprintf (stdout,
+	     "\n---------------- TIMINGS ----------------\n");
+    fprintf(stdout, "rational param(elapsed) %12.2f sec\n", rt1-rt0);
+    fprintf(stdout, "rational param(cpu) %16.2f sec\n", ct1-ct0);
+    fprintf(stdout, "-----------------------------------------\n");
   }
 
   if (get_param > 1) {
@@ -5018,7 +5039,7 @@ void msolve_julia(
     if (info_level > 0) {
         double st1 = cputime();
         double rt1 = realtime();
-        fprintf(stderr, "-------------------------------------------------\
+        fprintf(stderr, "\n-------------------------------------------------\
 -----------------------------------\n");
         fprintf(stderr, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
                 rt1-rt0, st1-st0);

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -2343,7 +2343,6 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
                 (unsigned long)st->application_nr_red);
         fprintf(stderr, "------------------------------------------\n");
       }
-      /* JB to change */
       /* if (info_level > 1) { */
       /*   fprintf(stderr, "Application phase %.2f Gops/sec\n", */
       /*           (st->application_nr_add + st->application_nr_mult) / 1000.0 / */
@@ -3328,7 +3327,6 @@ int real_msolve_qq(mpz_param_t *mpz_paramp, param_t **nmod_param, int *dim_ptr,
   double rt1 = realtime();
 
   if(info_level && print_gb == 0){
-    /* JB to change */
     /* fprintf( */
     /*     stderr, */
     /*     "Time for rational param: %13.2f (elapsed) sec / %5.2f sec (cpu)\n\n", */

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -2364,7 +2364,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 		    ca1-stf4);
 	    if (info_level > 1){
 	      fprintf(stdout,
-		      "application phase     %9.2f Gops/sec\n",
+		      "application phase          %9.2f Gops/sec\n",
 		      (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
 	    }
 	    fprintf(stdout,

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -2161,9 +2161,10 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
                                bsquvars);
   normalize_nmod_param(nmod_params[0]);
 
-  if (info_level) {
-    fprintf(stderr, "\nStarts multi-modular computations\n");
-  }
+  /* if (info_level) { */
+  /*   fprintf(stderr, "\nStarts multi-modular computations\n"); */
+  /* } */
+  /* print postponed */
 
   mpz_param_t tmp_mpz_param;
   mpz_param_init(tmp_mpz_param);
@@ -2370,6 +2371,13 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 	    fprintf(stdout,
 		    "-----------------------------------------\n");
       }
+      if (info_level) {
+	  fprintf(stdout,
+		  "\nmulti-modular steps\n");
+	  fprintf(stdout, "-------------------------------------------------\
+-----------------------------------------------------\n");
+      }
+
     }
     for (int i = 0; i < st->nthrds; i++) {
       if (bad_primes[i] == 0) {
@@ -2406,7 +2414,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
         nprimes++;
       } else {
         if (info_level) {
-          fprintf(stderr, "<bp: %d>\n", lp->p[i]);
+          fprintf(stdout, "<bp: %d>\n", lp->p[i]);
         }
         nbadprimes++;
         if (nbadprimes > nprimes) {
@@ -2432,7 +2440,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
       lpow2 = 2 * nprimes;
       doit = 0;
       if (info_level) {
-        fprintf(stderr, "\n<Step:%d/%.2f/%.2f>", nbdoit, scrr, t);
+        fprintf(stdout, "\n<Step:%d/%.2f/%.2f>", nbdoit, scrr, t);
       }
       prdone = 0;
     } else {
@@ -2442,7 +2450,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
     if ((LOG2(nprimes) > clog) ||
         (nbdoit != 1 && (nprimes % (lpow2 + 1) == 0))) {
       if (info_level) {
-        fprintf(stderr, "{%d}", nprimes);
+        fprintf(stdout, "{%d}", nprimes);
       }
       clog++;
       lpow2 = 2 * lpow2;
@@ -2456,12 +2464,17 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
     mpz_mul_ui((*mpz_paramp)->denom->coeffs[i - 1],
                (*mpz_paramp)->denom->coeffs[i - 1], i);
   }
+  if(info_level){
+    fprintf(stdout,
+	    "\n-------------------------------------------------\
+-----------------------------------------------------\n");
+  }
 
 
   if(info_level){
     /* fprintf(stderr, "\n%d primes used\n", nprimes); */
     /* fprintf(stderr, "Time for CRT + rational reconstruction = %.2f\n", strat); */
-    fprintf(stdout,"\n\n---------- COMPUTATIONAL DATA -----------\n");
+    fprintf(stdout,"\n---------- COMPUTATIONAL DATA -----------\n");
     fprintf(stdout, "#primes            %16lu\n", (unsigned long) nprimes);
     fprintf(stdout, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
     fprintf(stdout, "-----------------------------------------\n");

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1599,9 +1599,9 @@ static int32_t *initial_modular_step(
         long dquot = 0;
         int32_t *lmb = monomial_basis(bs->lml, bs->ht->nv, leadmons[0], &dquot);
 
-        if(md->info_level){
-            fprintf(stderr, "Dimension of quotient: %ld\n", dquot);
-        }
+        /* if(md->info_level){ */
+        /*     fprintf(stderr, "Dimension of quotient: %ld\n", dquot); */
+        /* } */
         if(print_gb==0){
 	    /* *bmatrix = build_matrixn_from_bs_trace(bdiv_xn, */
 	    /* 					 blen_gb_xn, */
@@ -1610,6 +1610,9 @@ static int32_t *initial_modular_step(
 	    /* 					 leadmons[0], bs->ht->nv, */
 	    /* 					 fc, */
 	    /* 					 md->info_level); */
+	    md->fglm_rtime = realtime();
+	    md->fglm_ctime = cputime();
+	    print_fglm_header (stdout,md);
 	    *bmatrix = build_matrixn_unstable_from_bs_trace(bdiv_xn,
 							    blen_gb_xn,
 							    bstart_cf_gb_xn,

--- a/src/neogb/data.h
+++ b/src/neogb/data.h
@@ -351,6 +351,7 @@ struct md_t
     double tracer_ctime;
     double rht_ctime;
     double nf_ctime;
+    double fglm_ctime;
 
     double round_rtime;
     double select_rtime;
@@ -363,6 +364,7 @@ struct md_t
     double tracer_rtime;
     double rht_rtime;
     double nf_rtime;
+    double fglm_rtime;
 
     int64_t num_pairsred;
     int64_t num_gb_crit;

--- a/src/neogb/meta_data.c
+++ b/src/neogb/meta_data.c
@@ -281,7 +281,7 @@ void get_and_print_final_statistics(
     get_final_statistics(st, bs);
 
     if (st->info_level > 0) {
-        fprintf(file, "\n---------------- TIMINGS ---------------\n");
+        fprintf(file, "\n---------------- TIMINGS ----------------\n");
         fprintf(file, "overall(elapsed) %11.2f sec\n", st->f4_rtime);
         fprintf(file, "overall(cpu) %15.2f sec\n", st->f4_ctime);
         if(st->trace_level == APPLY_TRACER) {


### PR DESCRIPTION
The goal of this PR is to homogenize how information is printed in msolve with option -v. It takes as a template the printing of F4 and reproduces it in FGLM and the lifting of Gröbner bases over rational numbers.
Below I give examples of the output in the terminal.

For the moment, I set this PR as a draft for several reasons:

1. Do we want such a homogenized printing and so should this be done to real roots isolation as well?
2. Contrary to F4, the code does not completely rely on the md_t struct of src/neogb/data.h. Should this be corrected?
3. Some printing are sent onto stdout and some to stderr. Should this be homogenized or at least clear which stream is used for what?

Comments are welcome!


Call of msolve over rational numbers with option -P 2

```
--------------- INPUT DATA ---------------
#variables                       6
#equations                       6
#invalid equations               0
field characteristic             0
homogeneous input?               0
signature-based computation      0
monomial order                 DRL
basis hash table resetting     OFF
linear algebra option            2
initial hash table size     131072 (2^17)
max pair selection             ALL
reduce gb                        1
#threads                         1
info level                       2
generate pbm files               0
------------------------------------------

Legend for f4 information
--------------------------------------------------------
deg       current degree of pairs selected in this round
sel       number of pairs selected in this round
pairs     total number of pairs in pair list
mat       matrix dimensions (# rows x # columns)
density   density of the matrix
new data  # new elements for basis in this round
          # zero reductions during linear algebra
time(rd)  time of the current f4 round in seconds given
          for real and cpu time
--------------------------------------------------------

deg     sel   pairs        mat          density            new data         time(rd) in sec (real|cpu)
------------------------------------------------------------------------------------------------------
  2       2       4      12 x 28         23.21%        2 new       0 zero         0.00 | 0.00         
  3       5       5      43 x 68         12.18%        5 new       0 zero         0.00 | 0.00         
  4      16      16     102 x 122        10.51%        6 new      10 zero         0.00 | 0.00         
  5      23      23     142 x 154        10.80%        4 new      19 zero         0.00 | 0.00         
  6      16      16     126 x 142        12.03%        1 new      15 zero         0.00 | 0.00         
  7       4       4     107 x 134        12.28%        0 new       4 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------
reduce final basis       25 x 57         36.98%       22 new       0 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------

---------------- TIMINGS ----------------
overall(elapsed)        0.00 sec
overall(cpu)            0.00 sec
select                  0.00 sec   8.7%
symbolic prep.          0.00 sec  13.1%
update                  0.00 sec  27.8%
convert                 0.00 sec  15.3%
linear algebra          0.00 sec  13.1%
reduce gb               0.00 sec   0.0%
-----------------------------------------

---------- COMPUTATIONAL DATA -----------
size of basis                    22
#terms in basis                 528
#pairs reduced                   66
#GM criterion                   210
#redundant elements               2
#rows reduced                   154
#zero reductions                 48
max. matrix data                142 x 154 (10.797%)
max. symbolic hash table size  2^11
max. basis hash table size     2^16
-----------------------------------------

Learning phase 0.00 Gops/sec

fglm steps                                               time(rd) in sec (real|cpu)
------------------------------------------------------------------------------------------------------
multiplication matrix                                          0.00 | 0.00         
scalar sequence                                                0.00 | 0.00         
elimination polynomial                                         0.00 | 0.00         
parametrizations                                               0.00 | 0.00         
------------------------------------------------------------------------------------------------------

---------------- TIMINGS ----------------
overall(elapsed)        0.00 sec
overall(cpu)            0.00 sec
-----------------------------------------

---------- COMPUTATIONAL DATA -----------
degree of ideal                  32
#dense rows                      11
#normal forms                     0
total density                    89.2%
density of the free part         89.2%
deg. elim. pol.                  32
deg. sqfr. elim. pol.            32
-----------------------------------------


---------------- TIMINGS ----------------
multi-mod overall(elapsed)      0.00 sec
multi-mod F4                    0.00 sec
multi-mod FGLM                  0.00 sec
application phase          0.00 Gops/sec
-----------------------------------------

multi-modular steps
------------------------------------------------------------------------------------------------------
[0][1][2][3][4][5]{2}{4}{8}
------------------------------------------------------------------------------------------------------

---------- COMPUTATIONAL DATA -----------
#primes                           8
#bad primes                       0
-----------------------------------------

---------------- TIMINGS ----------------
CRT and ratrecon(elapsed)       0.00 sec
-----------------------------------------

---------------- TIMINGS ----------------
rational param(elapsed)         0.01 sec
rational param(cpu)             0.01 sec
-----------------------------------------


------------------------------------------------------------------------------------
msolve overall time           0.01 sec (elapsed) /  0.01 sec (cpu)
------------------------------------------------------------------------------------
```

Call of msolve over rational numbers with option -g 2

```

--------------- INPUT DATA ---------------
#variables                       6
#equations                       6
#invalid equations               0
field characteristic             0
homogeneous input?               0
signature-based computation      0
monomial order                 DRL
basis hash table resetting     OFF
linear algebra option            2
initial hash table size     131072 (2^17)
max pair selection             ALL
reduce gb                        1
#threads                         1
info level                       2
generate pbm files               0
------------------------------------------

Legend for f4 information
--------------------------------------------------------
deg       current degree of pairs selected in this round
sel       number of pairs selected in this round
pairs     total number of pairs in pair list
mat       matrix dimensions (# rows x # columns)
density   density of the matrix
new data  # new elements for basis in this round
          # zero reductions during linear algebra
time(rd)  time of the current f4 round in seconds given
          for real and cpu time
--------------------------------------------------------

deg     sel   pairs        mat          density            new data         time(rd) in sec (real|cpu)
------------------------------------------------------------------------------------------------------
  2       2       4      12 x 28         23.21%        2 new       0 zero         0.00 | 0.00         
  3       5       5      43 x 68         12.18%        5 new       0 zero         0.00 | 0.00         
  4      16      16     102 x 122        10.51%        6 new      10 zero         0.00 | 0.00         
  5      23      23     142 x 154        10.80%        4 new      19 zero         0.00 | 0.00         
  6      16      16     126 x 142        12.03%        1 new      15 zero         0.00 | 0.00         
  7       4       4     107 x 134        12.28%        0 new       4 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------
reduce final basis       25 x 57         36.98%       22 new       0 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------

---------------- TIMINGS ----------------
overall(elapsed)        0.00 sec
overall(cpu)            0.00 sec
select                  0.00 sec   9.5%
symbolic prep.          0.00 sec  13.4%
update                  0.00 sec  28.3%
convert                 0.00 sec  13.1%
linear algebra          0.00 sec  13.6%
reduce gb               0.00 sec   0.0%
-----------------------------------------

---------- COMPUTATIONAL DATA -----------
size of basis                    22
#terms in basis                 528
#pairs reduced                   66
#GM criterion                   210
#redundant elements               2
#rows reduced                   154
#zero reductions                 48
max. matrix data                142 x 154 (10.797%)
max. symbolic hash table size  2^11
max. basis hash table size     2^16
-----------------------------------------

Learning phase 0.00 Gops/sec


---------- COMPUTATIONAL DATA -----------
[1][5][5][6][4][1]
#polynomials to lift             22
-----------------------------------------

---------------- TIMINGS ----------------
multi-mod overall(elapsed)      0.00 sec
application phase          0.00 Gops/sec
-----------------------------------------

multi-modular steps
------------------------------------------------------------------------------------------------------
{1}{2}<40.91%><90.91%>{4}<100.00%> 
------------------------------------------------------------------------------------------------------


---------- COMPUTATIONAL DATA -----------
Max coeff. bitsize               62
#primes                           6
#bad primes                       0
-----------------------------------------

---------------- TIMINGS ----------------
CRT     (elapsed)               0.00 sec
ratrecon(elapsed)               0.00 sec
-----------------------------------------


------------------------------------------------------------------------------------
msolve overall time           0.01 sec (elapsed) /  0.01 sec (cpu)
------------------------------------------------------------------------------------
```