### PR TITLE
fix bug in print of multi-modular steps not flushing the steps

### DIFF
--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -606,7 +606,7 @@ static int32_t * gb_modular_trace_learning(gb_modpoly_t modgbs,
                                            files_gb *files,
                                            int *success)
 {
-    double ca0, rt;
+    double ca0/*, rt*/;
     ca0 = realtime();
 
     bs_t *bs = NULL;
@@ -619,14 +619,15 @@ static int32_t * gb_modular_trace_learning(gb_modpoly_t modgbs,
       exit(1);
     }
 
-    rt = realtime()-ca0;
+    /* rt = realtime()-ca0; */
+    st->learning_rtime = realtime()-ca0;
 
     const ht_t *bht = bs->ht;
 
-    if(info_level > 1){
-        fprintf(stderr, "Learning phase %.2f Gops/sec\n",
-                (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/rt);
-    }
+    /* if(info_level > 1){ */
+    /*     fprintf(stderr, "Learning phase %.2f Gops/sec\n", */
+    /*             (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(st->learning_rtime)); */
+    /* } */
     if(info_level > 2){
         fprintf(stderr, "------------------------------------------\n");
         fprintf(stderr, "#ADDITIONS       %13lu\n", (unsigned long)st->trace_nr_add * 1000);
@@ -1338,10 +1339,11 @@ int msolve_gbtrace_qq(
     /*   } */
     /* } */
     if(info_level){
-      fprintf(stdout,"\n\n---------- COMPUTATIONAL DATA -----------\n");
+      fprintf(stdout,"\n---------- COMPUTATIONAL DATA -----------\n");
       int s= 0;
       for(int i = 0; i < dlift->nsteps; i++){
         fprintf(stdout, "[%d]", dlift->steps[i]);
+	fflush(stdout);
         s+=dlift->steps[i];
       }
       fprintf(stdout, "\n");
@@ -1457,6 +1459,9 @@ int msolve_gbtrace_qq(
 		  stf4);
 	  if (info_level > 1){
 	    fprintf(stdout,
+		    "learning phase             %9.2f Gops/sec\n",
+		    (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(st->learning_rtime));
+	    fprintf(stdout,
 		    "application phase          %9.2f Gops/sec\n",
 		    (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
 	  }
@@ -1506,11 +1511,13 @@ int msolve_gbtrace_qq(
         dlift->rr = 2*dlift->rr;
         if(info_level){
           fprintf(stdout, "(->%d)", dlift->rr);
+	  fflush(stdout);
         }
       }
       if(info_level){
         if(!(nprimes & (nprimes - 1))){
           fprintf(stdout, "{%d}", nprimes);
+	  fflush(stdout);
         }
       }
       apply = 0;
@@ -1523,6 +1530,7 @@ int msolve_gbtrace_qq(
       if(dlift->lstart != lstart){
         if(info_level){
           fprintf(stdout, "<%.2f%%>", 100* (float)MIN((dlift->lstart + 1), modgbs->ld)/modgbs->ld);
+	  fflush(stdout);
         }
         lstart = dlift->lstart;
       }

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1579,6 +1579,7 @@ static int32_t *initial_modular_step(
   int32_t empty_solution_set = 1;
   bs_t *bs = core_gba(gbg, md, &error, fc);
 
+  md->learning_rtime = realtime()-rt;
   print_tracer_statistics(stdout, rt, md);
 
   get_leading_ideal_information(num_gb, leadmons, 0, bs);
@@ -2364,6 +2365,9 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 		    ca1-stf4);
 	    if (info_level > 1){
 	      fprintf(stdout,
+		      "learning phase             %9.2f Gops/sec\n",
+		      (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(st->learning_rtime));
+	      fprintf(stdout,
 		      "application phase          %9.2f Gops/sec\n",
 		      (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
 	    }
@@ -2414,6 +2418,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
       } else {
         if (info_level) {
           fprintf(stdout, "<bp: %d>\n", lp->p[i]);
+	  fflush(stdout);
         }
         nbadprimes++;
         if (nbadprimes > nprimes) {
@@ -2440,6 +2445,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
       doit = 0;
       if (info_level) {
         fprintf(stdout, "\n<Step:%d/%.2f/%.2f>", nbdoit, scrr, t);
+	fflush(stdout);
       }
       prdone = 0;
     } else {
@@ -2450,6 +2456,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
         (nbdoit != 1 && (nprimes % (lpow2 + 1) == 0))) {
       if (info_level) {
         fprintf(stdout, "{%d}", nprimes);
+	fflush(stdout);
       }
       clog++;
       lpow2 = 2 * lpow2;

--- a/src/neogb/data.h
+++ b/src/neogb/data.h
@@ -365,6 +365,7 @@ struct md_t
     double rht_rtime;
     double nf_rtime;
     double fglm_rtime;
+    double learning_rtime;
 
     int64_t num_pairsred;
     int64_t num_gb_crit;

--- a/src/neogb/meta_data.c
+++ b/src/neogb/meta_data.c
@@ -86,10 +86,10 @@ void print_tracer_statistics(
     )
 {
     if (st->trace_level == APPLY_TRACER) {
-        if(st->info_level > 1){
-            fprintf(stderr, "Learning phase %.2f Gops/sec\n",
-                    (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(realtime()-rt));
-        }
+        /* if(st->info_level > 1){ */
+        /*     fprintf(stderr, "Learning phase %.2f Gops/sec\n", */
+        /*             (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(realtime()-rt)); */
+        /* } */
         if(st->info_level > 2){
             fprintf(stderr, "------------------------------------------\n");
             fprintf(stderr, "#ADDITIONS       %13lu\n", (unsigned long)st->trace_nr_add * 1000);


### PR DESCRIPTION
Learning phase speed is now printed with other computation times.

Changing the multi-modular steps printing from stderr to stdout made it not being printed live, this PR adds some `fflush(stdout)` to return to the previous behavior.