### PR TITLE
Fix 32-bit build

### DIFF
--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -47,9 +47,9 @@ typedef modpolys_struct modpolys_t[1];
 typedef struct {
   uint32_t alloc; /* alloc -> max number of primes */
   uint32_t nprimes; /* number of primes */
-  uint64_t *primes; /* array of prime numbers encoded with uint64_t to ensure
+  mp_limb_t *primes; /* array of prime numbers encoded with uint64_t to ensure
                        compatibility with flint */
-  uint64_t *cf_64; /* array of length equal to number of primes which will be used
+  mp_limb_t *cf_64; /* array of length equal to number of primes which will be used
                     to copy coefficients (hence ensuring compatibility with
                     flint) */
   uint32_t ld; /* number of polynomials */
@@ -167,8 +167,8 @@ static inline void gb_modpoly_init(gb_modpoly_t modgbs,
                                    int32_t *lm, int32_t *basis){
   modgbs->alloc = alloc;
   modgbs->nprimes = 0;
-  modgbs->primes = (uint64_t *)calloc(alloc, sizeof(uint64_t));
-  modgbs->cf_64 = (uint64_t *)calloc(alloc, sizeof(uint64_t));
+  modgbs->primes = (mp_limb_t *)calloc(alloc, sizeof(mp_limb_t));
+  modgbs->cf_64 = (mp_limb_t *)calloc(alloc, sizeof(uint64_t));
   modgbs->ld = ld;
   modgbs->nv = nv;
   modgbs->modpolys = (modpolys_t *)malloc(sizeof(modpolys_t) * ld);
@@ -205,8 +205,8 @@ static inline void gb_modpoly_realloc(gb_modpoly_t modgbs,
   uint32_t oldalloc = modgbs->alloc;
   modgbs->alloc += newalloc;
 
-  uint64_t *newprimes = (uint64_t *)realloc(modgbs->primes,
-                                            modgbs->alloc * sizeof(uint64_t));
+  mp_limb_t *newprimes = (mp_limb_t *)realloc(modgbs->primes,
+                                            modgbs->alloc * sizeof(mp_limb_t));
 
   if(newprimes == NULL){
     fprintf(stderr, "Problem when reallocating modgbs (primes)\n");
@@ -217,8 +217,8 @@ static inline void gb_modpoly_realloc(gb_modpoly_t modgbs,
     modgbs->primes[i] = 0;
   }
 
-  uint64_t *ncf_64 = (uint64_t *)realloc(modgbs->cf_64,
-                                         modgbs->alloc * sizeof(uint64_t));
+  mp_limb_t *ncf_64 = (mp_limb_t *)realloc(modgbs->cf_64,
+                                         modgbs->alloc * sizeof(mp_limb_t));
   if(ncf_64 == NULL){
     fprintf(stderr, "Problem when reallocating modgbs (cfs)\n");
     exit(1);
@@ -840,7 +840,7 @@ static inline void incremental_dlift_crt_full(gb_modpoly_t modgbs, data_lift_t d
                                               int32_t *coef, mpz_t mod_p, mpz_t prod_p,
                                               int thrds){
 
-  uint64_t newprime = modgbs->primes[modgbs->nprimes - 1 ];
+  mp_limb_t newprime = modgbs->primes[modgbs->nprimes - 1 ];
   /* all primes are assumed to be good primes */
   mpz_mul_ui(prod_p, mod_p, (uint32_t)newprime);
   for(int32_t k = 0; k < dl->end; k++){
@@ -986,7 +986,7 @@ static inline int verif_lifted_basis(gb_modpoly_t modgbs, data_lift_t dl,
   for(int32_t k = 0; k < modgbs->ld; k++){
     if(dl->check1[k]>=1 && dl->check2[k] > 0 && dl->check2[k] < NBCHECK){
       for(int i = 0; i < thrds; i++){
-        uint32_t prime = modgbs->primes[modgbs->nprimes - (thrds - i) ];
+        mp_limb_t prime = modgbs->primes[modgbs->nprimes - (thrds - i) ];
         for(int32_t c = 0; c < modgbs->modpolys[k]->len; c++){
           mpz_mul(den, modgbs->modpolys[k]->lm, modgbs->modpolys[k]->cf_qq[2*c+1]);
           uint32_t coef = modgbs->modpolys[k]->cf_32[c][modgbs->nprimes   - (thrds - i) ];
@@ -1016,7 +1016,7 @@ static inline int verif_lifted_rational_wcoef(gb_modpoly_t modgbs, data_lift_t d
     }
     for(int i = 0; i < thrds; i++){
 
-      uint32_t prime = modgbs->primes[modgbs->nprimes - (thrds - i) ];
+      mp_limb_t prime = modgbs->primes[modgbs->nprimes - (thrds - i) ];
       uint32_t coef = modgbs->modpolys[k]->cf_32[dl->coef[k]][modgbs->nprimes  - (thrds - i) ];
       int boo = verif_coef(dl->num[k], dl->den[k], prime, coef);
 

--- a/src/msolve/lifting.c
+++ b/src/msolve/lifting.c
@@ -204,7 +204,7 @@ static inline void copy_modular_matrix(trace_det_fglm_mat_t trace_det,
         int32_t *tmp = (int32_t *)realloc(trace_det->modular_matrices, 
                 sz2 * sizeof(int32_t));
         if(tmp == NULL){
-            fprintf(stderr, "Problem when allocating modular matrices (amount = %ld)\n", trace_det->mat_alloc * sz);
+            fprintf(stderr, "Problem when allocating modular matrices (amount = %zu)\n", trace_det->mat_alloc * sz);
             exit(1);
         }
         for(int64_t i = sz*old_alloc; i < sz2; i++){


### PR DESCRIPTION
This fixes a few compiler warnings and errors when building on 32-bit systems:

```
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I../.. -Wdate-time -D_FORTIFY_SOURCE=2 -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -msse4a -msha -maes -mavx -mfma -mavx2 -mrdrnd -mbmi -mbmi2 -madx -mabm -fopenmp -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/builds/math-team/msolve/debian/output/source_dir=. -fstack-protector-strong -Wformat -Werror=format-security -c libmsolve.c  -fPIC -DPIC -o .libs/libmsolve_la-libmsolve.o
In file included from msolve.c:24,
                 from libmsolve.c:35:
lifting.c: In function 'copy_modular_matrix':
lifting.c:207:83: warning: format '%ld' expects argument of type 'long int', but argument 3 has type 'size_t' {aka 'unsigned int'} [-Wformat=]
  207 |             fprintf(stderr, "Problem when allocating modular matrices (amount = %ld)\n", trace_det->mat_alloc * sz);
      |                                                                                 ~~^      ~~~~~~~~~~~~~~~~~~~~~~~~~
      |                                                                                   |                           |
      |                                                                                   long int                    size_t {aka unsigned int}
      |                                                                                 %d
In file included from msolve.c:25:
lifting-gb.c: In function 'crt_lift_modgbs':
lifting-gb.c:861:30: error: passing argument 2 of 'fmpz_comb_init' from incompatible pointer type [-Wincompatible-pointer-types]
  861 |   fmpz_comb_init(comb, modgbs->primes, modgbs->nprimes);
      |                        ~~~~~~^~~~~~~~
      |                              |
      |                              uint64_t * {aka long long unsigned int *}
In file included from msolve-data.h:26,
                 from libmsolve.c:25:
/usr/include/flint/fmpz.h:720:46: note: expected 'mp_srcptr' {aka 'const long unsigned int *'} but argument is of type 'uint64_t *' {aka 'long long unsigned int *'}
  720 | void fmpz_comb_init(fmpz_comb_t C, mp_srcptr primes, slong num_primes);
      |                                    ~~~~~~~~~~^~~~~~
lifting-gb.c:874:36: error: passing argument 2 of 'fmpz_multi_CRT_ui' from incompatible pointer type [-Wincompatible-pointer-types]
  874 |         fmpz_multi_CRT_ui(y, modgbs->cf_64,
      |                              ~~~~~~^~~~~~~
      |                                    |
      |                                    uint64_t * {aka long long unsigned int *}
/usr/include/flint/fmpz.h:724:49: note: expected 'mp_srcptr' {aka 'const long unsigned int *'} but argument is of type 'uint64_t *' {aka 'long long unsigned int *'}
  724 | void fmpz_multi_CRT_ui(fmpz_t output, mp_srcptr residues, const fmpz_comb_t comb, fmpz_comb_temp_t temp, int sign);
      |                                       ~~~~~~~~~~^~~~~~~~
make[3]: *** [Makefile:488: libmsolve_la-libmsolve.lo] Error 1
```

Full log: https://salsa.debian.org/math-team/msolve/-/jobs/6021204/raw

The two main changes are using `zu` as the format in `fprintf` and switching to pointers to `mp_limb_t` (which will be 32 bits on 32-bit systems and 64 bits on 64-bit systems) for the arrays of primes used when calling the flint CRT functions. 