### PR TITLE
Use int64_t instead of long for dquot member of msflags_t

### DIFF
--- a/src/msolve/msolve-data.h
+++ b/src/msolve/msolve-data.h
@@ -352,7 +352,7 @@ typedef msolvetrace_data_struct mstrace_t[1];
 
 typedef struct{
   int dim;
-  long dquot;
+  int64_t dquot;
   int32_t ht_size; /* initial_hts */
   int32_t nr_threads;
   int32_t max_nr_pairs;


### PR DESCRIPTION
In `groebner_qq`, we try to cast a pointer to this member to a pointer to an `int64_t`, which won't work on 32-bit systems where a `long` is only 32 bits.

Of course, another option would be the following:

```diff
--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1582,7 +1582,7 @@ gb_modpoly_t *groebner_qq(
         msflags_t flags)
 {
   int32_t *dim_ptr = &flags->dim;
-  int64_t *dquot_ptr = &flags->dquot;
+  long *dquot_ptr = &flags->dquot;
   int32_t ht_size = flags->ht_size;
   int32_t nr_threads = flags->nr_threads;
   int32_t max_nr_pairs = flags->max_nr_pairs;
```
`dquot_ptr` doesn't appear to actually be used yet, so I'm not sure which one would be best.