### PR TITLE
Fix for issue #192

### DIFF
--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -4035,13 +4035,11 @@ restart:
 	  int dim = - 2;
 	  long dquot = -1;
 
-    if(elim_block_len > 0 && print_gb == 0){
-      if(info_level){
-        fprintf(stderr, "Warning: elim order not available for rational parametrizations\n");
-        fprintf(stderr, "Computing Groebner basis\n");
-        print_gb=2;
+      if(elim_block_len > 0 && print_gb == 0){
+          fprintf(stderr, "Warning: elim order not available for rational parametrizations\n");
+          fprintf(stderr, "Computing Groebner basis\n");
+          print_gb=2;
       }
-    }
 	  b = real_msolve_qq(mpz_paramp,
                        &param,
                        &dim,
@@ -4706,11 +4704,9 @@ restart:
             long dquot = -1;
 
             if(elim_block_len && print_gb == 0){
-              if(info_level){
                 fprintf(stderr, "Warning: elim order not available for rational parametrizations\n");
                 fprintf(stderr, "Computing Groebner basis\n");
                 print_gb=2;
-              }
             }
 
             if(print_gb){


### PR DESCRIPTION
For elimination orders we do not provide the rational parametrisation but switch to the lifting of the DRL GB. This switch falsely depended on the setting of `info_level`, which triggered issue #192 and is fixed in this PR.