### PR TITLE
Fix return value of check_linear_forms

### DIFF
--- a/src/msolve/lifting.c
+++ b/src/msolve/lifting.c
@@ -760,6 +760,7 @@ static inline int check_linear_forms(trace_det_fglm_mat_t trace_det,
             if(!b) return 0;
         }
     }
+    return 1;
 }
 
 static inline void check_matrix(trace_det_fglm_mat_t trace_det, 


### PR DESCRIPTION
I got the following warning when building msolve with LLVM Clang 19 on macOS:

```
libtool: compile:  clang -DHAVE_CONFIG_H -I. -I../.. -mmmx -msse -msse2 -msse3 -mssse3 -msse4.1 -msse4.2 -maes -g -O2 -c libmsolve.c  -fno-common -DPIC -o .libs/libmsolve_la-libmsolve.o
In file included from libmsolve.c:35:
In file included from ./msolve.c:24:
./lifting.c:763:1: warning: non-void function does not return a value in all control paths [-Wreturn-type]
  763 | }
      | ^
1 warning generated.
```

This PR fixes the UB.