### PR TITLE
Use POSIX qsort_r on FreeBSD >= 14

### DIFF
--- a/src/neogb/sort_r.h
+++ b/src/neogb/sort_r.h
@@ -45,9 +45,11 @@ void sort_r(void *base, size_t nel, size_t width,
 #define _SORT_R_INLINE inline
 
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
-     defined __FreeBSD__ || defined __DragonFly__)
+     (defined __FreeBSD__ && !defined(qsort_r)) || defined __DragonFly__)
 #  define _SORT_R_BSD
-#elif (defined __MINGW32__ || defined __GLIBC__)
+#elif (defined __MINGW32__ || defined __GLIBC__ || \
+       (defined (__FreeBSD__) && defined(qsort_r)))
+
 #  define _SORT_R_LINUX
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
 #  define _SORT_R_WINDOWS
@@ -282,7 +284,7 @@ static _SORT_R_INLINE void sort_r_simple(void *base, size_t nel, size_t w,
   #if defined _SORT_R_LINUX
 
     typedef int(* __compar_d_fn_t)(const void *, const void *, void *);
-    extern void qsort_r(void *base, size_t nel, size_t width,
+    extern void (qsort_r)(void *base, size_t nel, size_t width,
                         __compar_d_fn_t __compar, void *arg)
       __attribute__((nonnull (1, 4)));
 


### PR DESCRIPTION
Prior to FreeBSD 14, qsort_r's arguments were the original BSD style, where the thunk was the first argument to the comparison function. However, the GNU style, where the thunk was the last argument, was eventually adopted as the POSIX standard.  FreeBSD switched to this beginning with FreeBSD 14.

So when compiling on FreeBSD, we first check to see whether to use the BSD-style or GNU-style qsort_r declaration.

This patch is based on https://github.com/noporpoise/sort_r/pull/15