### PR TITLE
add a cast on the returned value of realloc

### DIFF
--- a/src/neogb/modular.h
+++ b/src/neogb/modular.h
@@ -100,7 +100,7 @@ static inline void generate_lucky_primes(
 
     lp->old =   lp->ld;
     lp->ld  +=  nr_new_primes;
-    lp->p   =   realloc(lp->p, (unsigned long)(lp->ld) * sizeof(uint32_t));
+    lp->p   =   (uint32_t *)realloc(lp->p, (unsigned long)(lp->ld) * sizeof(uint32_t));
 
     mpz_t last_prime;
     mpz_init(last_prime);


### PR DESCRIPTION
When the header msolve.h is included in a C++ code, C++ compilers (e.g., g++ 14.2.0) generate an error on macos about an invalid conversion from 'void*' to 'uint32_t*':
```
/msolve/msolve/../neogb/modular.h:104:24: error: invalid conversion from 'void*' to 'uint32_t*' {aka 'unsigned int*'} [-fpermissive]
  104 |     lp->p   =   realloc(lp->p, (unsigned long)(lp->ld) * sizeof(uint32_t));
      |                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |                        |
      |                        void*
```
The function realloc returns a void* pointer but lp->p  is a uint32_t*. So a cast is required.

To reproduce the problem on macos, the C++ source code (myprog.cpp) contains only:
```
#include "msolve/msolve/msolve.h"
```
and the command line is: g++ -c myprog.cpp 
 
