### PR TITLE
Fix segmentation fault with -O0

### DIFF
--- a/src/neogb/data.h
+++ b/src/neogb/data.h
@@ -36,8 +36,8 @@
 #include <omp.h>
 #else
 typedef int omp_int_t;
-inline omp_int_t omp_get_thread_num(void) { return 0;}
-inline omp_int_t omp_get_max_threads(void) { return 1;}
+static inline omp_int_t omp_get_thread_num(void) { return 0;}
+static inline omp_int_t omp_get_max_threads(void) { return 1;}
 #endif
 
 #define PARALLEL_HASHING 0


### PR DESCRIPTION
If one compiles `msolve` on macOS, without OpenMP support and without optimization:

```
$ export PATH=$PATH:/opt/homebrew/bin
$ ./autogen.sh
$ ./configure LDFLAGS="-L$(brew --prefix)/lib/" CFLAGS="-I$(brew --prefix)/include/"
$ make
``` 

One gets a `msolve` binary that segfaults on almost all inputs.

This is not caught by CI since https://github.com/algebraic-solving/msolve/commit/c710b2b31a6f5b558213f6d31e35ab6c9d34d39c sets `CFLAGS=-O2`, so the two inline functions are replaced by constant values. Indeed, `CFLAGS=-O3 -fno-inline` also reproduces the issue.