### PR TITLE
Port to Windows

### DIFF
--- a/.github/workflows/msolve.yml
+++ b/.github/workflows/msolve.yml
@@ -13,11 +13,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: windows-latest, shell: msys2 }
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
     steps:
+      - name: Disable CRLF conversion on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+               git config --global core.autocrlf false
+               git config --global core.eol lf
       - uses: actions/checkout@v6
+      - name: Set up MSYS2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
       - name: "Install dependencies"
         run: |
                if [ "$RUNNER_OS" == "Linux" ]; then
@@ -25,6 +40,8 @@ jobs:
                     sudo apt install libgmp-dev libflint-dev libmpfr-dev libntl-dev
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     brew install autoconf automake libtool gmp flint mpfr ntl
+               elif [ "$RUNNER_OS" == "Windows" ]; then
+                    pacman -S --noconfirm autotools mingw-w64-x86_64-toolchain mingw-w64-x86_64-gmp mingw-w64-x86_64-flint mingw-w64-x86_64-mpfr mingw-w64-x86_64-ntl
                else
                     echo "$RUNNER_OS not supported"
                     exit 1
@@ -33,7 +50,7 @@ jobs:
         run: ./autogen.sh
       - name: configure
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     ./configure
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     ./configure LDFLAGS="-L$(brew --prefix)/lib/" \
@@ -51,7 +68,7 @@ jobs:
         run: cat test-suite.log || true
       - name: make distcheck
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     make distcheck
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     make distcheck LDFLAGS="-L$(brew --prefix)/lib/" \
@@ -66,15 +83,30 @@ jobs:
 
   build-fixed-seed:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: windows-latest, shell: msys2 }
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
     steps:
+      - name: Disable CRLF conversion on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+               git config --global core.autocrlf false
+               git config --global core.eol lf
       - uses: actions/checkout@v6
+      - name: Set up MSYS2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
       - name: "Install dependencies"
         run: |
                if [ "$RUNNER_OS" == "Linux" ]; then
@@ -82,6 +114,8 @@ jobs:
                     sudo apt install libgmp-dev libflint-dev libmpfr-dev libntl-dev
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     brew install autoconf automake libtool gmp flint mpfr ntl
+               elif [ "$RUNNER_OS" == "Windows" ]; then
+                    pacman -S --noconfirm autotools mingw-w64-x86_64-toolchain mingw-w64-x86_64-gmp mingw-w64-x86_64-flint mingw-w64-x86_64-mpfr mingw-w64-x86_64-ntl
                else
                     echo "$RUNNER_OS not supported"
                     exit 1
@@ -90,7 +124,7 @@ jobs:
         run: ./autogen.sh
       - name: configure
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     ./configure
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     ./configure LDFLAGS="-L$(brew --prefix)/lib/" \
@@ -108,7 +142,7 @@ jobs:
         run: cat test-suite.log || true
       - name: make distcheck with fixed seed
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     make distcheck DISTCHECK_CONFIGURE_FLAGS="SEED=1617753600"
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     make distcheck LDFLAGS="-L$(brew --prefix)/lib/" \

--- a/.github/workflows/msolve.yml
+++ b/.github/workflows/msolve.yml
@@ -13,12 +13,28 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - macos-26-intel
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: macos-26-intel, shell: bash }
+          - { os: windows-latest, shell: msys2 }
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
     steps:
+      - name: Disable CRLF conversion on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+               git config --global core.autocrlf false
+               git config --global core.eol lf
       - uses: actions/checkout@v6
+      - name: Set up MSYS2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
       - name: "Install dependencies"
         run: |
                if [ "$RUNNER_OS" == "Linux" ]; then
@@ -26,6 +42,8 @@ jobs:
                     sudo apt install libgmp-dev libflint-dev libmpfr-dev libntl-dev
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     brew install autoconf automake libtool gmp flint mpfr ntl
+               elif [ "$RUNNER_OS" == "Windows" ]; then
+                    pacman -S --noconfirm autotools mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-gmp mingw-w64-ucrt-x86_64-flint mingw-w64-ucrt-x86_64-mpfr mingw-w64-ucrt-x86_64-ntl
                else
                     echo "$RUNNER_OS not supported"
                     exit 1
@@ -34,7 +52,7 @@ jobs:
         run: ./autogen.sh
       - name: configure
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     ./configure
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     ./configure LDFLAGS="-L$(brew --prefix)/lib/" \
@@ -52,7 +70,7 @@ jobs:
         run: cat test-suite.log || true
       - name: make distcheck
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     make distcheck
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     make distcheck LDFLAGS="-L$(brew --prefix)/lib/" \
@@ -67,15 +85,32 @@ jobs:
 
   build-fixed-seed:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+        include:
+          - { os: ubuntu-latest, shell: bash }
+          - { os: macos-latest, shell: bash }
+          - { os: macos-26-intel, shell: bash }
+          - { os: windows-latest, shell: msys2 }
+    defaults:
+      run:
+        shell: ${{ matrix.shell }} {0}
     steps:
+      - name: Disable CRLF conversion on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+               git config --global core.autocrlf false
+               git config --global core.eol lf
       - uses: actions/checkout@v6
+      - name: Set up MSYS2
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
       - name: "Install dependencies"
         run: |
                if [ "$RUNNER_OS" == "Linux" ]; then
@@ -83,6 +118,8 @@ jobs:
                     sudo apt install libgmp-dev libflint-dev libmpfr-dev libntl-dev
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     brew install autoconf automake libtool gmp flint mpfr ntl
+               elif [ "$RUNNER_OS" == "Windows" ]; then
+                    pacman -S --noconfirm autotools mingw-w64-ucrt-x86_64-toolchain mingw-w64-ucrt-x86_64-gmp mingw-w64-ucrt-x86_64-flint mingw-w64-ucrt-x86_64-mpfr mingw-w64-ucrt-x86_64-ntl
                else
                     echo "$RUNNER_OS not supported"
                     exit 1
@@ -91,7 +128,7 @@ jobs:
         run: ./autogen.sh
       - name: configure
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     ./configure
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     ./configure LDFLAGS="-L$(brew --prefix)/lib/" \
@@ -109,7 +146,7 @@ jobs:
         run: cat test-suite.log || true
       - name: make distcheck with fixed seed
         run: |
-               if [ "$RUNNER_OS" == "Linux" ]; then
+               if [ "$RUNNER_OS" == "Linux" ] || [ "$RUNNER_OS" == "Windows" ]; then
                     make distcheck DISTCHECK_CONFIGURE_FLAGS="SEED=1617753600"
                elif [ "$RUNNER_OS" == "macOS" ]; then
                     make distcheck LDFLAGS="-L$(brew --prefix)/lib/" \

--- a/src/fglm/Makefile.am
+++ b/src/fglm/Makefile.am
@@ -6,6 +6,7 @@ libfglm_la_CFLAGS		= $(SIMD_FLAGS) $(CPUEXT_FLAGS) $(OPENMP_CFLAGS) -Wall -Wextr
 
 EXTRA_DIST	=		fglm.h \
                 libfglm.h \
+					aligned_alloc.h \
 								berlekamp_massey.c \
 								data_fglm.c \
 								fglm_core.c \

--- a/src/fglm/aligned_alloc.h
+++ b/src/fglm/aligned_alloc.h
@@ -1,0 +1,50 @@
+/* This file is part of msolve.
+ *
+ * msolve is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * msolve is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with msolve.  If not, see <https://www.gnu.org/licenses/>
+ *
+ * Authors:
+ * Jérémy Berthomieu
+ * Christian Eder
+ * Mohab Safey El Din */
+
+#ifndef ALIGNED_ALLOC_HEADER_H
+#define ALIGNED_ALLOC_HEADER_H
+
+#ifdef _WIN32
+
+#include <errno.h>
+#include <malloc.h>
+
+static inline int posix_memalign(void **__memptr, size_t __alignment, size_t __size)
+{
+    void *p = _aligned_malloc(__size, __alignment);
+    if (!p)
+    {
+        return ENOMEM;
+    }
+    *__memptr = p;
+    return 0;
+}
+#endif
+
+static inline void posix_memalign_free(void *__p)
+{
+#ifdef _WIN32
+    _aligned_free(__p);
+#else
+    free(__p);
+#endif
+}
+
+#endif /* ALIGNED_ALLOC_HEADER_H */

--- a/src/fglm/data_fglm.c
+++ b/src/fglm/data_fglm.c
@@ -26,14 +26,15 @@
 #include <flint/nmod_poly_factor.h>
 #include <flint/ulong_extras.h>
 
+#include "aligned_alloc.h"
 
 static inline void free_sp_mat_fglm(sp_matfglm_t *mat){
   if(mat!=NULL){
-    free(mat->dense_mat);
-    free(mat->triv_idx);
-    free(mat->triv_pos);
-    free(mat->dense_idx);
-    free(mat->dst);
+    posix_memalign_free(mat->dense_mat);
+    posix_memalign_free(mat->triv_idx);
+    posix_memalign_free(mat->triv_pos);
+    posix_memalign_free(mat->dense_idx);
+    posix_memalign_free(mat->dst);
     free(mat);
   }
 }
@@ -80,10 +81,10 @@ static inline fglm_data_t *allocate_fglm_data(szmat_t nrows, szmat_t ncols, szma
 
 
 static inline void free_fglm_data(fglm_data_t *data){
-  free(data->vecinit);
-  free(data->res);
-  free(data->vecmult);
-  free(data->vvec);
+  posix_memalign_free(data->vecinit);
+  posix_memalign_free(data->res);
+  posix_memalign_free(data->vecmult);
+  posix_memalign_free(data->vvec);
   free(data->pts);
   free(data);
 }

--- a/src/fglm/data_fglm.c
+++ b/src/fglm/data_fglm.c
@@ -27,14 +27,15 @@
 #include <flint/ulong_extras.h>
 #include "../msolve/streams.h"
 
+#include "aligned_alloc.h"
 
 static inline void free_sp_mat_fglm(sp_matfglm_t *mat){
   if(mat!=NULL){
-    free(mat->dense_mat);
-    free(mat->triv_idx);
-    free(mat->triv_pos);
-    free(mat->dense_idx);
-    free(mat->dst);
+    posix_memalign_free(mat->dense_mat);
+    posix_memalign_free(mat->triv_idx);
+    posix_memalign_free(mat->triv_pos);
+    posix_memalign_free(mat->dense_idx);
+    posix_memalign_free(mat->dst);
     free(mat);
   }
 }
@@ -81,10 +82,10 @@ static inline fglm_data_t *allocate_fglm_data(szmat_t nrows, szmat_t ncols, szma
 
 
 static inline void free_fglm_data(fglm_data_t *data){
-  free(data->vecinit);
-  free(data->res);
-  free(data->vecmult);
-  free(data->vvec);
+  posix_memalign_free(data->vecinit);
+  posix_memalign_free(data->res);
+  posix_memalign_free(data->vecmult);
+  posix_memalign_free(data->vvec);
   free(data->pts);
   free(data);
 }

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -71,6 +71,8 @@ double omp_get_wtime(void) { return realtime();}
 #include "../upolmat/nmod_poly_mat_pmbasis.c"
 #endif
 
+#include "aligned_alloc.h"
+
 void print_fglm_data(
         FILE *file,
         const md_t * const st,
@@ -613,9 +615,9 @@ static void generate_matrix_sequence(sp_matfglm_t *matxn, fglm_data_t *data,
     exit(1);
 #endif
   }
-  free(Rmat);
-  free(res);
-  free(tres);
+  posix_memalign_free(Rmat);
+  posix_memalign_free(res);
+  posix_memalign_free(tres);
 
 }
 #endif
@@ -1337,7 +1339,7 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 #endif
 
 #if DEBUGFGLM >= 1
-  FILE *fmat = fopen("/tmp/matrix.fglm", "w");
+  FILE *fmat = fopen("/tmp/matrix.fglm", "wb");
   display_fglm_matrix(fmat, matrix);
   fclose(fmat);
 #endif
@@ -1539,7 +1541,7 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
 #endif
 
 #if DEBUGFGLM >= 1
-  FILE *fmat = fopen("/tmp/matrix.fglm", "w");
+  FILE *fmat = fopen("/tmp/matrix.fglm", "wb");
   display_fglm_matrix(fmat, matrix);
   fclose(fmat);
 #endif
@@ -1758,7 +1760,7 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
 #endif
 
 #if DEBUGFGLM >= 1
-  FILE *fmat = fopen("/tmp/matrix.fglm", "w");
+  FILE *fmat = fopen("/tmp/matrix.fglm", "wb");
   display_fglm_colon_matrix(fmat, matrix);
   fclose(fmat);
 #endif

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -72,6 +72,8 @@ double omp_get_wtime(void) { return realtime();}
 #include "../upolmat/nmod_poly_mat_pmbasis.c"
 #endif
 
+#include "aligned_alloc.h"
+
 void print_fglm_data(
         FILE *file,
         const md_t * const st,
@@ -614,9 +616,9 @@ static void generate_matrix_sequence(sp_matfglm_t *matxn, fglm_data_t *data,
     exit(1);
 #endif
   }
-  free(Rmat);
-  free(res);
-  free(tres);
+  posix_memalign_free(Rmat);
+  posix_memalign_free(res);
+  posix_memalign_free(tres);
 
 }
 #endif
@@ -1338,7 +1340,7 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 #endif
 
 #if DEBUGFGLM >= 1
-  FILE *fmat = fopen("/tmp/matrix.fglm", "w");
+  FILE *fmat = fopen("/tmp/matrix.fglm", "wb");
   display_fglm_matrix(fmat, matrix);
   fclose(fmat);
 #endif
@@ -1540,7 +1542,7 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
 #endif
 
 #if DEBUGFGLM >= 1
-  FILE *fmat = fopen("/tmp/matrix.fglm", "w");
+  FILE *fmat = fopen("/tmp/matrix.fglm", "wb");
   display_fglm_matrix(fmat, matrix);
   fclose(fmat);
 #endif
@@ -1759,7 +1761,7 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
 #endif
 
 #if DEBUGFGLM >= 1
-  FILE *fmat = fopen("/tmp/matrix.fglm", "w");
+  FILE *fmat = fopen("/tmp/matrix.fglm", "wb");
   display_fglm_colon_matrix(fmat, matrix);
   fclose(fmat);
 #endif

--- a/src/msolve/Makefile.am
+++ b/src/msolve/Makefile.am
@@ -8,6 +8,7 @@ libmsolve_la_LIBADD		=	../usolve/libusolve.la ../fglm/libfglm.la ../neogb/libneo
 
 EXTRA_DIST	=	  msolve-data.h \
 								msolve.h \
+								getdelim.h \
 								msolve-data.c \
 								duplicate.c \
 								hilbert.c \

--- a/src/msolve/getdelim.h
+++ b/src/msolve/getdelim.h
@@ -1,0 +1,131 @@
+/* getdelim.h --- Implementation of replacement getdelim/getline function.
+   Copyright (C) 1994, 1996-1998, 2001, 2003, 2005-2025 Free Software
+   Foundation, Inc.
+
+   This file is free software: you can redistribute it and/or modify
+   it under the terms of the GNU Lesser General Public License as
+   published by the Free Software Foundation; either version 2.1 of the
+   License, or (at your option) any later version.
+
+   This file is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
+
+/* Ported from glibc by Simon Josefsson. */
+
+#ifndef GETDELIM_HEADER_H
+#define GETDELIM_HEADER_H
+
+#ifdef _WIN32
+
+#include <stdio.h>
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <errno.h>
+
+static inline void
+alloc_failed (void)
+{
+#if defined _WIN32 && ! defined __CYGWIN__
+  /* Avoid errno problem without using the realloc module; see:
+     https://lists.gnu.org/r/bug-gnulib/2016-08/msg00025.html  */
+  errno = ENOMEM;
+#endif
+}
+
+/* Read up to (and including) a DELIMITER from FP into *LINEPTR (and
+   NUL-terminate it).  *LINEPTR is a pointer returned from malloc (or
+   NULL), pointing to *N characters of space.  It is realloc'ed as
+   necessary.  Returns the number of characters read (not including
+   the null terminator), or -1 on error or EOF.  */
+
+static inline ssize_t
+getdelim (char **lineptr, size_t *n, int delimiter, FILE *fp)
+{
+  ssize_t result;
+  size_t cur_len = 0;
+
+  if (lineptr == NULL || n == NULL || fp == NULL)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  if (*lineptr == NULL || *n == 0)
+    {
+      char *new_lineptr;
+      *n = 120;
+      new_lineptr = (char *) realloc (*lineptr, *n);
+      if (new_lineptr == NULL)
+        {
+          alloc_failed ();
+          return -1;
+        }
+      *lineptr = new_lineptr;
+    }
+
+  for (;;)
+    {
+      int i;
+
+      i = getc (fp);
+      if (i == EOF)
+        {
+          result = -1;
+          break;
+        }
+
+      /* Make enough space for len+1 (for final NUL) bytes.  */
+      if (cur_len + 1 >= *n)
+        {
+          size_t needed_max =
+            SSIZE_MAX < SIZE_MAX ? (size_t) SSIZE_MAX + 1 : SIZE_MAX;
+          size_t needed = 2 * *n + 1;   /* Be generous. */
+          char *new_lineptr;
+
+          if (needed_max < needed)
+            needed = needed_max;
+          if (cur_len + 1 >= needed)
+            {
+              errno = EOVERFLOW;
+              return -1;
+            }
+
+          new_lineptr = (char *) realloc (*lineptr, needed);
+          if (new_lineptr == NULL)
+            {
+              alloc_failed ();
+              return -1;
+            }
+
+          *lineptr = new_lineptr;
+          *n = needed;
+        }
+
+      (*lineptr)[cur_len] = i;
+      cur_len++;
+
+      if (i == delimiter)
+        break;
+    }
+  (*lineptr)[cur_len] = '\0';
+  result = cur_len ? cur_len : result;
+
+  return result;
+}
+
+static inline ssize_t
+getline (char **lineptr, size_t *n, FILE *stream)
+{
+  return getdelim (lineptr, n, '\n', stream);
+}
+
+#endif
+
+#endif /* GETDELIM_HEADER_H */

--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -1531,10 +1531,10 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
         count++;
         if(len_xn < count && i < dquot){
           fprintf(stderr, "One should not arrive here (build_matrix)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
           free(matrix);
 
           free(len_gb_xn);
@@ -1548,11 +1548,11 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
         fprintf(stderr, "Multiplication by ");
         display_monomial_full(stderr, nv, NULL, 0, exp);
         fprintf(stderr, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
         matrix  = NULL;
 
@@ -1913,12 +1913,12 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	    free(lens);
 	    free(exps);
 	    free(cfs);
-	    free(matrix->dense_mat);
-	    free(matrix->dense_idx);
-	    free(matrix->triv_idx);
-	    free(matrix->triv_pos);
-	    free(matrix->zero_idx);
-	    free(matrix->dst);
+	    posix_memalign_free(matrix->dense_mat);
+	    posix_memalign_free(matrix->dense_idx);
+	    posix_memalign_free(matrix->triv_idx);
+	    posix_memalign_free(matrix->triv_pos);
+	    posix_memalign_free(matrix->zero_idx);
+	    posix_memalign_free(matrix->dst);
 	    free(matrix);
 	    free(evi);
 	    free(len_gb_xn);
@@ -2371,12 +2371,12 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	    free(lens);
 	    free(exps);
 	    free(cfs);
-	    free(matrix->dense_mat);
-	    free(matrix->dense_idx);
-	    free(matrix->triv_idx);
-	    free(matrix->triv_pos);
-	    free(matrix->dst);
-	    /* free(matrix->zero_idx); */
+	    posix_memalign_free(matrix->dense_mat);
+	    posix_memalign_free(matrix->dense_idx);
+	    posix_memalign_free(matrix->triv_idx);
+	    posix_memalign_free(matrix->triv_pos);
+	    posix_memalign_free(matrix->dst);
+	    /* posix_memalign_free(matrix->zero_idx); */
 	    free(matrix);
 	    free(evi);
 	    free(len_gb_xn);
@@ -2589,11 +2589,11 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
         count++;
         if(len_xn < count && i < dquot){
           fprintf(stderr, "One should not arrive here (build_matrix)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
           free(len_gb_xn);
@@ -2607,11 +2607,11 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
         fprintf(stderr, "Multiplication by ");
         display_monomial_full(stderr, nv, NULL, 0, exp);
         fprintf(stderr, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
         free(len_gb_xn);
@@ -2786,11 +2786,11 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
         count++;
         if(len_xn < count && i < dquot){
           fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
           free(len_gb_xn);
@@ -2804,11 +2804,11 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
 	fprintf(stdout, "Multiplication by ");
 	display_monomial_full(stdout, nv, NULL, 0, exp);
 	fprintf(stdout, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
         free(len_gb_xn);
@@ -2979,11 +2979,11 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
         count++;
         if(len_xn < count && i < dquot){
           fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
           free(len_gb_xn);
@@ -2997,11 +2997,11 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
         fprintf(stderr, "Multiplication by ");
         display_monomial_full(stderr, nv, NULL, 0, exp);
         fprintf(stderr, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
         free(len_gb_xn);
@@ -3153,11 +3153,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
         count++;
         if(len_xn < count && i < dquot){
           fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
 	  free_basis_without_hash_table(&tbr);
@@ -3182,11 +3182,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
 	count_nf++;
 	if (count_not_lm < count_nf && i < dquot) {
           fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
 	  free_basis_without_hash_table(&tbr);
@@ -3206,11 +3206,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
         fprintf(stderr, "Multiplication by ");
         display_monomial_full(stderr, nv, NULL, 0, exp);
         fprintf(stderr, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
 	free_basis_without_hash_table(&tbr);

--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -1532,10 +1532,10 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
         count++;
         if(len_xn < count && i < dquot){
           fprintf(ERRSTREAM, "One should not arrive here (build_matrix)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
           free(matrix);
 
           free(len_gb_xn);
@@ -1549,11 +1549,11 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
         fprintf(ERRSTREAM, "Multiplication by ");
         display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
         fprintf(ERRSTREAM, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
         matrix  = NULL;
 
@@ -1914,12 +1914,12 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	    free(lens);
 	    free(exps);
 	    free(cfs);
-	    free(matrix->dense_mat);
-	    free(matrix->dense_idx);
-	    free(matrix->triv_idx);
-	    free(matrix->triv_pos);
-	    free(matrix->zero_idx);
-	    free(matrix->dst);
+	    posix_memalign_free(matrix->dense_mat);
+	    posix_memalign_free(matrix->dense_idx);
+	    posix_memalign_free(matrix->triv_idx);
+	    posix_memalign_free(matrix->triv_pos);
+	    posix_memalign_free(matrix->zero_idx);
+	    posix_memalign_free(matrix->dst);
 	    free(matrix);
 	    free(evi);
 	    free(len_gb_xn);
@@ -2372,12 +2372,12 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	    free(lens);
 	    free(exps);
 	    free(cfs);
-	    free(matrix->dense_mat);
-	    free(matrix->dense_idx);
-	    free(matrix->triv_idx);
-	    free(matrix->triv_pos);
-	    free(matrix->dst);
-	    /* free(matrix->zero_idx); */
+	    posix_memalign_free(matrix->dense_mat);
+	    posix_memalign_free(matrix->dense_idx);
+	    posix_memalign_free(matrix->triv_idx);
+	    posix_memalign_free(matrix->triv_pos);
+	    posix_memalign_free(matrix->dst);
+	    /* posix_memalign_free(matrix->zero_idx); */
 	    free(matrix);
 	    free(evi);
 	    free(len_gb_xn);
@@ -2590,11 +2590,11 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
         count++;
         if(len_xn < count && i < dquot){
           fprintf(ERRSTREAM, "One should not arrive here (build_matrix)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
           free(len_gb_xn);
@@ -2608,11 +2608,11 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
         fprintf(ERRSTREAM, "Multiplication by ");
         display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
         fprintf(ERRSTREAM, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
         free(len_gb_xn);
@@ -2787,11 +2787,11 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
         count++;
         if(len_xn < count && i < dquot){
           fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
           free(len_gb_xn);
@@ -2805,11 +2805,11 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
 	fprintf(VERBSTREAM, "Multiplication by ");
 	display_monomial_full(VERBSTREAM, nv, NULL, 0, exp);
 	fprintf(VERBSTREAM, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
         free(len_gb_xn);
@@ -2980,11 +2980,11 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
         count++;
         if(len_xn < count && i < dquot){
           fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
           free(len_gb_xn);
@@ -2998,11 +2998,11 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
         fprintf(ERRSTREAM, "Multiplication by ");
         display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
         fprintf(ERRSTREAM, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
         free(len_gb_xn);
@@ -3154,11 +3154,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
         count++;
         if(len_xn < count && i < dquot){
           fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
 	  free_basis_without_hash_table(&tbr);
@@ -3183,11 +3183,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
 	count_nf++;
 	if (count_not_lm < count_nf && i < dquot) {
           fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
-          free(matrix->dense_mat);
-          free(matrix->dense_idx);
-          free(matrix->triv_idx);
-          free(matrix->triv_pos);
-          free(matrix->dst);
+          posix_memalign_free(matrix->dense_mat);
+          posix_memalign_free(matrix->dense_idx);
+          posix_memalign_free(matrix->triv_idx);
+          posix_memalign_free(matrix->triv_pos);
+          posix_memalign_free(matrix->dst);
           free(matrix);
 
 	  free_basis_without_hash_table(&tbr);
@@ -3207,11 +3207,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
         fprintf(ERRSTREAM, "Multiplication by ");
         display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
         fprintf(ERRSTREAM, " gets outside the staircase\n");
-        free(matrix->dense_mat);
-        free(matrix->dense_idx);
-        free(matrix->triv_idx);
-        free(matrix->triv_pos);
-        free(matrix->dst);
+        posix_memalign_free(matrix->dense_mat);
+        posix_memalign_free(matrix->dense_idx);
+        posix_memalign_free(matrix->triv_idx);
+        posix_memalign_free(matrix->triv_pos);
+        posix_memalign_free(matrix->dst);
         free(matrix);
 
 	free_basis_without_hash_table(&tbr);

--- a/src/msolve/iofiles.c
+++ b/src/msolve/iofiles.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "getdelim.h"
+
 static inline void store_exponent(const char *term, data_gens_ff_t *gens, int32_t pos)
 {
     len_t i, j, k;

--- a/src/msolve/iofiles.c
+++ b/src/msolve/iofiles.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "getdelim.h"
+
 #include "streams.h"
 
 static inline void store_exponent(const char *term, data_gens_ff_t *gens, int32_t pos)

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1815,7 +1815,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
 
   FILE *ofile;
   if (flags->files->out_file != NULL) {
-    ofile = fopen(flags->files->out_file, "w+");
+    ofile = fopen(flags->files->out_file, "wb+");
   } else {
     ofile = stdout;
   }
@@ -1852,7 +1852,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
   if(flags->print_gb > 1){
 
     if(flags->files->out_file != NULL){
-      FILE *ofile = fopen(flags->files->out_file, "a+");
+      FILE *ofile = fopen(flags->files->out_file, "ab+");
       display_gbmodpoly_cf_qq(ofile, (*modgbsp), gens);
       fclose(ofile);
     }
@@ -1862,7 +1862,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
   }
   if(flags->print_gb == 1){
     if(flags->files->out_file != NULL){
-      FILE *ofile = fopen(flags->files->out_file, "a+");
+      FILE *ofile = fopen(flags->files->out_file, "ab+");
       display_lm_gbmodpoly_cf_qq(ofile, (*modgbsp), gens);
       fclose(ofile);
     }

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1816,7 +1816,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
 
   FILE *ofile;
   if (flags->files->out_file != NULL) {
-    ofile = fopen(flags->files->out_file, "w+");
+    ofile = fopen(flags->files->out_file, "wb+");
   } else {
     ofile = OUTSTREAM;
   }
@@ -1853,7 +1853,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
   if(flags->print_gb > 1){
 
     if(flags->files->out_file != NULL){
-      FILE *ofile = fopen(flags->files->out_file, "a+");
+      FILE *ofile = fopen(flags->files->out_file, "ab+");
       display_gbmodpoly_cf_qq(ofile, (*modgbsp), gens);
       fclose(ofile);
     }
@@ -1863,7 +1863,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
   }
   if(flags->print_gb == 1){
     if(flags->files->out_file != NULL){
-      FILE *ofile = fopen(flags->files->out_file, "a+");
+      FILE *ofile = fopen(flags->files->out_file, "ab+");
       display_lm_gbmodpoly_cf_qq(ofile, (*modgbsp), gens);
       fclose(ofile);
     }

--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -520,7 +520,7 @@ int main(int argc, char **argv){
 
     /* clear out_file if given */
     if(files->out_file != NULL){
-      FILE *ofile = fopen(files->out_file, "w");
+      FILE *ofile = fopen(files->out_file, "wb");
       if(ofile == NULL){
         fprintf(stderr, "Cannot open output file\n");
         exit(1);

--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -522,7 +522,7 @@ int main(int argc, char **argv){
 
     /* clear out_file if given */
     if(files->out_file != NULL){
-      FILE *ofile = fopen(files->out_file, "w");
+      FILE *ofile = fopen(files->out_file, "wb");
       if(ofile == NULL){
         fprintf(ERRSTREAM, "Cannot open output file\n");
         exit(1);

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1540,7 +1540,7 @@ static inline void print_groebner_basis(files_gb *files,
   if (md->print_gb) {
     int32_t gfc = md->gfc;
     md->gfc = fc;
-    print_ff_basis_data(files->out_file, "a", bs, bs->ht, md, gens,
+    print_ff_basis_data(files->out_file, "ab", bs, bs->ht, md, gens,
                         md->print_gb);
     md->gfc = gfc;
   }
@@ -3848,7 +3848,7 @@ int real_msolve_qq(mpz_param_t *mpz_paramp, param_t **nmod_param, int *dim_ptr,
 void display_arrays_of_real_roots(files_gb *files, int32_t len,
                                   real_point_t **lreal_pts, long *lnbr) {
   if (files->out_file != NULL) {
-    FILE *ofile = fopen(files->out_file, "a+");
+    FILE *ofile = fopen(files->out_file, "ab+");
     fprintf(ofile, "[");
     for (int i = 0; i < len - 1; i++) {
       display_real_points(ofile, lreal_pts[i], lnbr[i]);
@@ -3875,7 +3875,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
                     real_point_t **real_pts_ptr, int info_level) {
   if (dquot == 0) {
     if (files->out_file != NULL) {
-      FILE *ofile = fopen(files->out_file, "a+");
+      FILE *ofile = fopen(files->out_file, "ab+");
       fprintf(ofile, "[-1]:\n");
       fclose(ofile);
     } else {
@@ -3887,7 +3887,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
   if (dim == 0 && dquot >= 0) {
     (*mpz_paramp)->nvars = gens->nvars;
     if (files->out_file != NULL) {
-      FILE *ofile = fopen(files->out_file, "a+");
+      FILE *ofile = fopen(files->out_file, "ab+");
       fprintf(ofile, "[0, ");
       if (get_param >= 1 || gens->field_char) {
         mpz_param_out_str_maple(ofile, gens, dquot, *mpz_paramp, param);
@@ -3919,7 +3919,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
       fprintf(stdout, "The ideal has positive dimension\n");
     }
     if (files->out_file != NULL) {
-      FILE *ofile2 = fopen(files->out_file, "a+");
+      FILE *ofile2 = fopen(files->out_file, "ab+");
       // 1 because dim is >0
       fprintf(ofile2, "[1, %d, -1, []]:\n", gens->nvars);
       fclose(ofile2);
@@ -4159,7 +4159,7 @@ restart:
                     return -1;
                 }
                 if (print_gb) {
-		  print_ff_basis_data(files->out_file, "a", bs, bht,
+		  print_ff_basis_data(files->out_file, "ab", bs, bht,
                     st, gens, print_gb);
 		}
             }
@@ -4637,7 +4637,7 @@ restart:
             }
             /* print all reduced elements in tbr, first normal_form ones
              * are the input elements */
-            print_ff_nf_data(files->out_file, "a", 0, normal_form, tbr, bht, st, gens, 2);
+            print_ff_nf_data(files->out_file, "ab", 0, normal_form, tbr, bht, st, gens, 2);
             if (normal_form_matrix > 0) {
                 /* sht and hcm will store the union of the support
                  * of all normal forms in tbr. */

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -1542,7 +1542,7 @@ static inline void print_groebner_basis(files_gb *files,
   if (md->print_gb) {
     int32_t gfc = md->gfc;
     md->gfc = fc;
-    print_ff_basis_data(files->out_file, "a", bs, bs->ht, md, gens,
+    print_ff_basis_data(files->out_file, "ab", bs, bs->ht, md, gens,
                         md->print_gb);
     md->gfc = gfc;
   }
@@ -3850,7 +3850,7 @@ int real_msolve_qq(mpz_param_t *mpz_paramp, param_t **nmod_param, int *dim_ptr,
 void display_arrays_of_real_roots(files_gb *files, int32_t len,
                                   real_point_t **lreal_pts, long *lnbr) {
   if (files->out_file != NULL) {
-    FILE *ofile = fopen(files->out_file, "a+");
+    FILE *ofile = fopen(files->out_file, "ab+");
     fprintf(ofile, "[");
     for (int i = 0; i < len - 1; i++) {
       display_real_points(ofile, lreal_pts[i], lnbr[i]);
@@ -3877,7 +3877,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
                     real_point_t **real_pts_ptr, int info_level) {
   if (dquot == 0) {
     if (files->out_file != NULL) {
-      FILE *ofile = fopen(files->out_file, "a+");
+      FILE *ofile = fopen(files->out_file, "ab+");
       fprintf(ofile, "[-1]:\n");
       fclose(ofile);
     } else {
@@ -3889,7 +3889,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
   if (dim == 0 && dquot >= 0) {
     (*mpz_paramp)->nvars = gens->nvars;
     if (files->out_file != NULL) {
-      FILE *ofile = fopen(files->out_file, "a+");
+      FILE *ofile = fopen(files->out_file, "ab+");
       fprintf(ofile, "[0, ");
       if (get_param >= 1 || gens->field_char) {
         mpz_param_out_str_maple(ofile, gens, dquot, *mpz_paramp, param);
@@ -3921,7 +3921,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
       fprintf(VERBSTREAM, "The ideal has positive dimension\n");
     }
     if (files->out_file != NULL) {
-      FILE *ofile2 = fopen(files->out_file, "a+");
+      FILE *ofile2 = fopen(files->out_file, "ab+");
       // 1 because dim is >0
       fprintf(ofile2, "[1, %d, -1, []]:\n", gens->nvars);
       fclose(ofile2);
@@ -4161,7 +4161,7 @@ restart:
                     return -1;
                 }
                 if (print_gb) {
-		  print_ff_basis_data(files->out_file, "a", bs, bht,
+		  print_ff_basis_data(files->out_file, "ab", bs, bht,
                     st, gens, print_gb);
 		}
             }
@@ -4639,7 +4639,7 @@ restart:
             }
             /* print all reduced elements in tbr, first normal_form ones
              * are the input elements */
-            print_ff_nf_data(files->out_file, "a", 0, normal_form, tbr, bht, st, gens, 2);
+            print_ff_nf_data(files->out_file, "ab", 0, normal_form, tbr, bht, st, gens, 2);
             if (normal_form_matrix > 0) {
                 /* sht and hcm will store the union of the support
                  * of all normal forms in tbr. */


### PR DESCRIPTION
This work was done during the [JNCF 2025](https://sourcesup.renater.fr/www/orga-jncf/index-2025.html) and is now rebased on master. I guess I won't have time to clean up everything or split it into multiple PRs before going on vacation tonight, so I'm marking it as a draft (but at least it can serve as a demo).

In short, this is achieved by providing the following headers:

- `src/fglm/aligned_alloc.h`, which provides a handwritten implementation of `posix_memalign` on Windows. I also provided `posix_memalign_free` for the reason in https://learn.microsoft.com/en-us/cpp/standard-library/cstdlib?view=msvc-170#remarks-6, and modified files doing `free` over memory allocated by `posix_memalign` to use `posix_memalign_free`.
- `src/msolve/getdelim.h`, which provides Gnulib's implementation of `getdelim` and `getline` on Windows.

In addition, I added `b` to fopen access modes so that we have LF instead of CRLF on Windows.

All tests passed on CI and my aarch64-windows machine.