### PR TITLE
Memory leak mulmat

### DIFF
--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -1765,8 +1765,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
       exps[(count_not_lm + i*suppsize+j)*nv+nv-1]=bht->ev[hm[j]][evi[nv-1]];
     }
   }
-  tbr = initialize_basis(st);
-  tbr->ht = bht;
+  tbr = initialize_basis(st, bht);
 #if REDUCTION_ALLINONE
   import_input_data(tbr, st, 0, tobereduced, lens, exps, (void *)cfs, NULL);
   tbr->ld = tbr->lml  =  tobereduced;
@@ -2000,8 +1999,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 			     tbr, bht, evi, st, nv, maxdeg);
   }
 #else /* the shifts of phi are now reduced */
-  tbr = initialize_basis(st);
-  tbr->ht = bht;
+  tbr = initialize_basis(st, bht);
   import_input_data(tbr, st, count_not_lm, tobereduced, lens, exps, (void *)cfs, NULL);
   tbr->ld = tbr->lml  =  2*nv-2;
   /* printf ("%d imported\n",2*nv-2); */
@@ -2215,8 +2213,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
       exps[(count_not_lm + i*suppsize+j)*nv+nv-1]=bht->ev[hm[j]][evi[nv-1]];
     }
   }
-  tbr = initialize_basis(st);
-  tbr->ht = bht;
+  tbr = initialize_basis(st, bht);
   import_input_data(tbr, st, 0, tobereduced, lens, exps, (void *)cfs, NULL);
   tbr->ld = tbr->lml  =  tobereduced;
   /* printf ("%ld imported\n",tobereduced); */
@@ -3078,10 +3075,8 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
   long count_not_lm = matrix->nnfs;
   if (count_not_lm) {
     md_t *md = copy_meta_data(st,fc);
-    tbr = initialize_basis(md);
-    free_hash_table(&(tbr->ht));
+    tbr = initialize_basis(md, ht);
     exp_t *mul = (exp_t *)calloc(ht->evl, sizeof(exp_t));
-    tbr->ht = ht;
     /* reduction */
     import_input_data(tbr, md, 0, count_not_lm, lens_extra_nf, exps_extra_nf,
 		      (void *)cfs_extra_nf, NULL);
@@ -3651,10 +3646,8 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   bs_t *tbr;
   if (count_not_lm) {
     md_t *md = copy_meta_data(st,fc);
-    tbr = initialize_basis(md);
-    free_hash_table(&(tbr->ht));
+    tbr = initialize_basis(md, ht);
     exp_t *mul = (exp_t *)calloc(bs->ht->evl, sizeof(exp_t));
-    tbr->ht = ht;
     /* reduction */
     import_input_data(tbr, md, 0, count_not_lm, lens_extra_nf, exps_extra_nf,
 		      (void *)cfs_extra_nf, NULL);

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -2013,7 +2013,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
   /*******************
    * initialize basis
    *******************/
-  bs_t *bs_qq = initialize_basis(st);
+  bs_t *bs_qq = initialize_basis(st, NULL);
   /* read in ideal, move coefficients to integers */
   import_input_data(bs_qq, st, 0, st->ngens_input, lens, exps, cfs,
                     invalid_gens);
@@ -3750,8 +3750,7 @@ restart:
                     bs->lml     = bs->ld;
                 }
             } else {
-                sat = initialize_basis(st);
-                sat->ht = bht;
+                sat = initialize_basis(st, bht);
                 import_input_data(sat, st, gens->ngens-saturate, gens->ngens, gens->lens, gens->exps, (void *)gens->cfs, NULL);
 
                 sat->ld = sat->lml  =  saturate;
@@ -3883,8 +3882,7 @@ restart:
             /* initialize data for elements to be reduced,
              * NOTE: Don't initialize BEFORE running core_f4, bht may
              * change, so hash values of tbr may become wrong. */
-            tbr = initialize_basis(st);
-            tbr->ht = bht;
+            tbr = initialize_basis(st, bht);
             import_input_data(tbr, st, gens->ngens-1, gens->ngens, gens->lens, gens->exps, (void *)gens->cfs, NULL);
             tbr->ld = tbr->lml  =  1;
             /* normalize_initial_basis(tbr, st->gfc); */
@@ -4238,8 +4236,7 @@ restart:
             /* initialize data for elements to be reduced,
              * NOTE: Don't initialize BEFORE running core_f4, bht may
              * change, so hash values of tbr may become wrong. */
-            tbr = initialize_basis(st);
-            tbr->ht = bht;
+            tbr = initialize_basis(st, bht);
             import_input_data(tbr, st, gens->ngens-normal_form, gens->ngens,
                     gens->lens, gens->exps, (void *)gens->cfs, NULL);
             tbr->ld = tbr->lml  =  normal_form;
@@ -4568,7 +4565,7 @@ restart:
             /*******************
              * initialize basis
              *******************/
-            bs_t *bs_qq = initialize_basis(st);
+            bs_t *bs_qq = initialize_basis(st, NULL);
             /* initialize basis hash table, update hash table, symbolic hash table */
             ht_t *bht = bs_qq->ht;
             /* hash table to store the hashes of the multiples of
@@ -4621,8 +4618,7 @@ restart:
                     bs_qq->lml     = bs_qq->ld;
                 }
             }
-            sat_qq = initialize_basis(st);
-            sat_qq->ht = bht;
+            sat_qq = initialize_basis(st, bht);
             import_input_data(
                     sat_qq, st, gens->ngens-saturate, gens->ngens,
                     gens->lens, gens->exps, (void *)gens->mpz_cfs, NULL);

--- a/src/neogb/basis.c
+++ b/src/neogb/basis.c
@@ -157,7 +157,8 @@ void free_basis_without_hash_table(
 }
 
 bs_t *initialize_basis(
-        md_t *md
+        md_t *md,
+        ht_t *ht
         )
 {
     bs_t *bs  = (bs_t *)calloc(1, sizeof(bs_t));
@@ -168,7 +169,11 @@ bs_t *initialize_basis(
     bs->constant  = 0;
     bs->sz        = md->init_bs_sz;
     bs->mltdeg    = 0;
-    bs->ht        = initialize_basis_hash_table(md);
+    if (ht == NULL) {
+        bs->ht        = initialize_basis_hash_table(md);
+    } else {
+        bs->ht = ht;
+    }
 
     /* initialize basis elements data */
     bs->hm    = (hm_t **)malloc((unsigned long)bs->sz * sizeof(hm_t *));

--- a/src/neogb/basis.h
+++ b/src/neogb/basis.h
@@ -40,7 +40,8 @@ void remove_content_of_initial_basis(
         );
 
 bs_t *initialize_basis(
-        md_t *md
+        md_t *md,
+        ht_t *ht
         );
 
 bs_t *copy_basis_mod_p(

--- a/src/neogb/engine.c
+++ b/src/neogb/engine.c
@@ -80,7 +80,7 @@ int initialize_gba_input_data(
 
 
     /* initialize basis */
-    bs  = initialize_basis(st);
+    bs  = initialize_basis(st, NULL);
     ht_t *bht = bs->ht;
 
     import_input_data(bs, st, 0, st->ngens_input, lens, exps, cfs, invalid_gens);

--- a/src/neogb/f4sat.c
+++ b/src/neogb/f4sat.c
@@ -546,7 +546,7 @@ int core_f4sat(
     st->max_gb_degree = INT32_MAX;
 
     /* elements of kernel in saturation step, to be added to basis bs */
-    bs_t *kernel  = initialize_basis(st);
+    bs_t *kernel  = initialize_basis(st, NULL);
 
     /* reset bs->ld for first update process */
     bs->ld  = 0;

--- a/src/neogb/la_ff_32.c
+++ b/src/neogb/la_ff_32.c
@@ -2788,12 +2788,6 @@ static void exact_sparse_reduced_echelon_form_sat_ff_32(
     /* saturation elements we have to reduce with the known pivots first */
     hm_t **upivs  = sat->hm;
 
-    /* temporary storage for elements to be saturated */
-    /* bs_t *tmp = initialize_basis(sat->ld); */
-    /* temporary storage for corresponding multipliers
-     * which then generate the kernel elements */
-    /* bs_t *mul = initialize_basis(sat->ld); */
-
     int64_t *dr  = (int64_t *)malloc(
             (uint64_t)ncols * st->nthrds * sizeof(int64_t));
     /* mo need to have any sharing dependencies on parallel computation,

--- a/src/neogb/modular.c
+++ b/src/neogb/modular.c
@@ -431,7 +431,7 @@ bs_t *f4sat_trace_application_test_phase(
     ht_t *sht = initialize_secondary_hash_table(bht, st);
 
     /* elements of kernel in saturation step, to be added to basis bs */
-    bs_t *kernel  = initialize_basis(st);
+    bs_t *kernel  = initialize_basis(st, NULL);
 
     /* reset bs->ld for first update process */
     bs->ld  = 0;
@@ -724,7 +724,7 @@ bs_t *f4sat_trace_application_phase(
     st->ht    = sht;
 
     /* elements of kernel in saturation step, to be added to basis bs */
-    bs_t *kernel  = initialize_basis(st);
+    bs_t *kernel  = initialize_basis(st, NULL);
 
     bs->ld  = st->ngens;
 
@@ -1210,7 +1210,7 @@ bs_t *f4sat_trace_learning_phase_1(
     st->max_gb_degree = INT32_MAX;
 
     /* elements of kernel in saturation step, to be added to basis bs */
-    bs_t *kernel  = initialize_basis(st);
+    bs_t *kernel  = initialize_basis(st, NULL);
 
     /* reset bs->ld for first update process */
     bs->ld  = 0;
@@ -1539,7 +1539,7 @@ bs_t *f4sat_trace_learning_phase_2(
     st->max_gb_degree = INT32_MAX;
 
     /* elements of kernel in saturation step, to be added to basis bs */
-    bs_t *kernel  = initialize_basis(st);
+    bs_t *kernel  = initialize_basis(st, NULL);
 
     /* reset bs->ld for first update process */
     bs->ld  = 0;
@@ -1863,7 +1863,7 @@ int64_t f4_trace_julia(
     /*******************
     * initialize basis
     *******************/
-    bs_t *bs_qq = initialize_basis(st);
+    bs_t *bs_qq = initialize_basis(st, NULL);
     /* initialize basis hash table, update hash table, symbolic hash table */
     ht_t *bht = initialize_basis_hash_table(st);
     /* hash table to store the hashes of the multiples of

--- a/src/neogb/nf.c
+++ b/src/neogb/nf.c
@@ -183,8 +183,7 @@ int64_t export_nf(
     /* initialize data for elements to be reduced,
      * NOTE: Don't initialize BEFORE running core_f4, bht may
      * change, so hash values of tbr may become wrong. */
-    tbr = initialize_basis(md);
-    tbr->ht = bht;
+    tbr = initialize_basis(md, bht);
     import_input_data(tbr, md, 0, nr_tbr_gens,
             tbr_lens, tbr_exps, (void *)tbr_cfs, NULL);
     tbr->ld = tbr->lml  =  nr_tbr_gens;

--- a/src/neogb/sba.c
+++ b/src/neogb/sba.c
@@ -673,7 +673,7 @@ int core_sba_schreyer(
     crit_t *rew = initialize_signature_criteria(st);
 
     /* initialize an empty basis for keeping the real basis elements */
-    bs_t *bs = initialize_basis(st);
+    bs_t *bs = initialize_basis(st, NULL);
 
     /* sort initial elements, highest lead term first */
     sort_r(in->hm, (unsigned long)in->ld, sizeof(hm_t *),


### PR DESCRIPTION
This PR removes some memory leaks when building the multiplication matrix using non-trivial normal form computations.

On Eco-11, with the default option -d 2, we go from 100 MB for maximum resident set size to 32 MB.
On Eco-11, with the option -d 4, we go from 120 MB for maximum resident set size to 69 MB.
On Eco-12, with the default option -d 2, we go from 880 MB for maximum resident set size to 570 MB.
On Eco-12, with the option -d 4, we go from 680 MB for maximum resident set size to 410 MB.

On Henrion-6, with the default option -d 2, we go from 220 MB for maximum resident set size to 29 MB.
On Henrion-7, with the default option -d 2, we go from 6100 MB for maximum resident set size to 580 MB.

Thanks to @ederc for helping me!