### PR TITLE
handles 0x0 matrix edge case

### DIFF
--- a/src/neogb/symbol.c
+++ b/src/neogb/symbol.c
@@ -777,5 +777,9 @@ static int preprocessing(
     } else {
         generate_matrix_from_trace(mat, bs, md);
     }
-    return 0;
+    if (mat->nc == 0) {
+        return 1;
+    } else {
+        return 0;
+    }
 }


### PR DESCRIPTION
Handles an edge case (0x0 matrices) that might occur during the tracing process.