### PR TITLE
Fix unsigned absolute value

### DIFF
--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -3137,7 +3137,9 @@ static int evaluate_coordinate(mpz_param_t param, interval *rt, real_point_t pt,
     mpz_neg(val_up, val_up);
     mpz_swap(val_up, val_do);
 
-    long alpha = abs(mpz_sizeinbase(den_do, 2) + mpz_sizeinbase(param->cfs[pos], 2) - mpz_sizeinbase(val_do, 2)) / prec;
+    size_t sz = mpz_sizeinbase(den_do, 2) + mpz_sizeinbase(param->cfs[pos], 2)
+                - mpz_sizeinbase(val_do, 2);
+    long alpha = labs((long) sz) / prec;
     long dec = MAX(2,2*alpha) * prec;
 
     mpz_mul_2exp(val_up, val_up, dec);


### PR DESCRIPTION
`mpz_sizeinbase` returns `size_t`, which is unsigned.  `abs` acts on `int`.  This removes a warning generated by default on Clang.