### PR TITLE
Add CI runner with FLINT dev version

### DIFF
--- a/.github/workflows/msolve.yml
+++ b/.github/workflows/msolve.yml
@@ -74,7 +74,7 @@ jobs:
       - name: "Build FLINT"
         run: |
           git clone --depth=1 https://github.com/flintlib/flint
-          ./bootstrap.sh && ./configure CC=${CC} --with-ntl --enable-assert
+          cd flint && ./bootstrap.sh && ./configure CC=${CC} --with-ntl --enable-assert
           $MAKE && sudo make install && sudo ldconfig
       - name: "Build and Test msolve"
         run: |


### PR DESCRIPTION
This adds a CI runner which uses the developer version of FLINT, as available from its github repository.