### PR TITLE
Improve portability of shebangs

### DIFF
--- a/doc/examples/elim2_char1073741827.sh
+++ b/doc/examples/elim2_char1073741827.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -e 2 -g 2 -f elim_char1073741827.ms -o elim2_char1073741827.res

--- a/doc/examples/elim_char1073741827.sh
+++ b/doc/examples/elim_char1073741827.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -e 1 -g 2 -f elim_char1073741827.ms -o elim_char1073741827.res

--- a/doc/examples/empty_char0.sh
+++ b/doc/examples/empty_char0.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -f empty_char0.ms -o empty_char0.res

--- a/doc/examples/grevlex_char1073741827.sh
+++ b/doc/examples/grevlex_char1073741827.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -g 2 -f grevlex_char1073741827.ms -o grevlex_char1073741827.res

--- a/doc/examples/grevlex_lm_char1073741827.sh
+++ b/doc/examples/grevlex_lm_char1073741827.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -g 1 -f grevlex_char1073741827.ms -o grevlex_lm_char1073741827.res

--- a/doc/examples/hypersurface_char0.sh
+++ b/doc/examples/hypersurface_char0.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -f hypersurface_char0.ms -o hypersurface_char0.res

--- a/doc/examples/param_and_reals_char0.sh
+++ b/doc/examples/param_and_reals_char0.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -P 1 -f param_char0.ms -o param_and_reals_char0.res

--- a/doc/examples/param_char0.sh
+++ b/doc/examples/param_char0.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -P 2 -f param_char0.ms -o param_char0.res

--- a/doc/examples/param_char65521.sh
+++ b/doc/examples/param_char65521.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -P 2 -f param_char65521.ms -o param_char65521.res

--- a/doc/examples/param_simple.sh
+++ b/doc/examples/param_simple.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -P 2 -f param_simple.ms -o param_simple.res

--- a/doc/examples/reals_dim0.sh
+++ b/doc/examples/reals_dim0.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -f reals_dim0.ms -o reals_dim0.res

--- a/doc/examples/reals_dim0_prec256.sh
+++ b/doc/examples/reals_dim0_prec256.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -p 256 -f reals_dim0.ms -o reals_dim0_prec256.res

--- a/doc/examples/saturate_char1073741827.sh
+++ b/doc/examples/saturate_char1073741827.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -S -g 2 -f saturate_char1073741827.ms -o saturate_char1073741827.res

--- a/doc/examples/simple_char0.sh
+++ b/doc/examples/simple_char0.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -f simple_char0.ms -o simple_char0.res

--- a/doc/examples/simple_char65521.sh
+++ b/doc/examples/simple_char65521.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ../../msolve -f simple_char65521.ms -o simple_char65521.res

--- a/test/diff/diff_bug-2nd-prime-bad.sh
+++ b/test/diff/diff_bug-2nd-prime-bad.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=bug-2nd-prime-bad
 

--- a/test/diff/diff_bug-68.sh
+++ b/test/diff/diff_bug-68.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=bug-68
 

--- a/test/diff/diff_bug-empty-tracer.sh
+++ b/test/diff/diff_bug-empty-tracer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=bug-empty-tracer
 

--- a/test/diff/diff_choice-linear-form-qq.sh
+++ b/test/diff/diff_choice-linear-form-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=choice-linear-form-qq
 

--- a/test/diff/diff_cp-d3-n4-p2.sh
+++ b/test/diff/diff_cp-d3-n4-p2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=cp-d3-n4-p2
 

--- a/test/diff/diff_cyclic5-16.sh
+++ b/test/diff/diff_cyclic5-16.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=cyclic5-16
 

--- a/test/diff/diff_cyclic5-31.sh
+++ b/test/diff/diff_cyclic5-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=cyclic5-31
 

--- a/test/diff/diff_cyclic5-qq.sh
+++ b/test/diff/diff_cyclic5-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=cyclic5-qq
 

--- a/test/diff/diff_eco10-31.sh
+++ b/test/diff/diff_eco10-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=eco10-31
 

--- a/test/diff/diff_eco6-16.sh
+++ b/test/diff/diff_eco6-16.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=eco6-16
 

--- a/test/diff/diff_eco6-31.sh
+++ b/test/diff/diff_eco6-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=eco6-31
 

--- a/test/diff/diff_eco6-qq.sh
+++ b/test/diff/diff_eco6-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=eco6-qq
 

--- a/test/diff/diff_elim-31.sh
+++ b/test/diff/diff_elim-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=elim-31
 

--- a/test/diff/diff_elim-qq.sh
+++ b/test/diff/diff_elim-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=elim-qq
 

--- a/test/diff/diff_f4sat-31.sh
+++ b/test/diff/diff_f4sat-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=f4sat-31
 

--- a/test/diff/diff_f4sat-byone-31.sh
+++ b/test/diff/diff_f4sat-byone-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=f4sat-byone-31
 

--- a/test/diff/diff_f4sat-field-char.sh
+++ b/test/diff/diff_f4sat-field-char.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=f4sat-field-char
 

--- a/test/diff/diff_f4sat-is-saturated-check.sh
+++ b/test/diff/diff_f4sat-is-saturated-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=f4sat-is-saturated-check
 

--- a/test/diff/diff_f4sat-zero-input.sh
+++ b/test/diff/diff_f4sat-zero-input.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=f4sat-zero-input
 

--- a/test/diff/diff_groebner-g2.sh
+++ b/test/diff/diff_groebner-g2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=groebner-g2
 

--- a/test/diff/diff_henrion5-qq.sh
+++ b/test/diff/diff_henrion5-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=henrion5-qq
 

--- a/test/diff/diff_input-overflow-16.sh
+++ b/test/diff/diff_input-overflow-16.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=input-overflow-16
 

--- a/test/diff/diff_issue-230-squared.sh
+++ b/test/diff/diff_issue-230-squared.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=issue-230-squared
 

--- a/test/diff/diff_issue-230.sh
+++ b/test/diff/diff_issue-230.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=issue-230
 

--- a/test/diff/diff_kat6-31.sh
+++ b/test/diff/diff_kat6-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=kat6-31
 

--- a/test/diff/diff_kat7-qq.sh
+++ b/test/diff/diff_kat7-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=kat7-qq
 

--- a/test/diff/diff_kat8-qq-truncate.sh
+++ b/test/diff/diff_kat8-qq-truncate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=kat8-qq-truncate
 

--- a/test/diff/diff_linear-qq.sh
+++ b/test/diff/diff_linear-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=linear-qq
 

--- a/test/diff/diff_maxbitsize-bug.sh
+++ b/test/diff/diff_maxbitsize-bug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=maxbitsize-bug
 

--- a/test/diff/diff_mq-2-1.sh
+++ b/test/diff/diff_mq-2-1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=mq-2-1
 

--- a/test/diff/diff_multy-16.sh
+++ b/test/diff/diff_multy-16.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=multy-16
 

--- a/test/diff/diff_multy-31.sh
+++ b/test/diff/diff_multy-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=multy-31
 

--- a/test/diff/diff_multy-qq.sh
+++ b/test/diff/diff_multy-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=multy-qq
 

--- a/test/diff/diff_nf-16.sh
+++ b/test/diff/diff_nf-16.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nf-16
 

--- a/test/diff/diff_nf-31.sh
+++ b/test/diff/diff_nf-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nf-31
 

--- a/test/diff/diff_nf-8.sh
+++ b/test/diff/diff_nf-8.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nf-8
 

--- a/test/diff/diff_nf-lm-bug.sh
+++ b/test/diff/diff_nf-lm-bug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nf-lm-bug
 

--- a/test/diff/diff_nonradical-radicalshape-no-square-31.sh
+++ b/test/diff/diff_nonradical-radicalshape-no-square-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nonradical-radicalshape-no-square-31
 

--- a/test/diff/diff_nonradical-radicalshape-no-square-qq.sh
+++ b/test/diff/diff_nonradical-radicalshape-no-square-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nonradical-radicalshape-no-square-qq
 

--- a/test/diff/diff_nonradical-radicalshape-qq.sh
+++ b/test/diff/diff_nonradical-radicalshape-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nonradical-radicalshape-qq
 

--- a/test/diff/diff_nonradical-shape-31.sh
+++ b/test/diff/diff_nonradical-shape-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nonradical-shape-31
 

--- a/test/diff/diff_nonradical-shape-qq.sh
+++ b/test/diff/diff_nonradical-shape-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nonradical-shape-qq
 

--- a/test/diff/diff_nonradical_radicalshape-31.sh
+++ b/test/diff/diff_nonradical_radicalshape-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=nonradical-radicalshape-31
 

--- a/test/diff/diff_one-16.sh
+++ b/test/diff/diff_one-16.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=one-16
 

--- a/test/diff/diff_one-31.sh
+++ b/test/diff/diff_one-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=one-31
 

--- a/test/diff/diff_one-qq.sh
+++ b/test/diff/diff_one-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=one-qq
 

--- a/test/diff/diff_radical-shape-31.sh
+++ b/test/diff/diff_radical-shape-31.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=radical-shape-31
 

--- a/test/diff/diff_radical-shape-qq.sh
+++ b/test/diff/diff_radical-shape-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=radical-shape-qq
 

--- a/test/diff/diff_realroot-extraction-exact-root.sh
+++ b/test/diff/diff_realroot-extraction-exact-root.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=realroot-extraction-exact-root
 

--- a/test/diff/diff_realroot1.sh
+++ b/test/diff/diff_realroot1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #test file for real root extraction with adaptative precision
 #For this test file, one coordinate of one solutions is very close to 0

--- a/test/diff/diff_reals-dim0-chgvar.sh
+++ b/test/diff/diff_reals-dim0-chgvar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=reals-dim0-chgvar
 

--- a/test/diff/diff_reals-dim0-extract.sh
+++ b/test/diff/diff_reals-dim0-extract.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=reals-dim0-extract
 

--- a/test/diff/diff_reals-dim0-swapvar.sh
+++ b/test/diff/diff_reals-dim0-swapvar.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=reals-dim0-swapvar
 

--- a/test/diff/diff_reals-dim0.sh
+++ b/test/diff/diff_reals-dim0.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=reals-dim0
 

--- a/test/diff/diff_test-lifting2.sh
+++ b/test/diff/diff_test-lifting2.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=test-lifting2
 

--- a/test/diff/diff_xy-qq.sh
+++ b/test/diff/diff_xy-qq.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 file=xy-qq
 


### PR DESCRIPTION
On FreeBSD and OpenBSD, `bash` is not located in `/bin`. On macOS, `/bin/bash` is stuck at version 3.2 (the last version under GPLv2), and users may prefer to install and use a newer version of `bash`. In both cases, having `#!/bin/bash` as the shebang causes inconveniences.

This PR suggests using `#!/usr/bin/env bash` instead.