### PR TITLE
Fix overflow on data duplication with elimination order

### DIFF
--- a/src/msolve/duplicate.c
+++ b/src/msolve/duplicate.c
@@ -394,7 +394,7 @@ static inline void duplicate_data_mthread_gbtrace(int nthreads,
                                                   trace_t **btrace){
 
 
-  const len_t len = num_gb[0] * (st->nvars);
+  const len_t len = num_gb[0] * (st->nvars - st->nev);
 
   for(int i = 0; i < nthreads; i++){
     leadmons_current[i] = (int32_t *)calloc(len, sizeof(int32_t));


### PR DESCRIPTION
When computing Gröbner basis with respect to an elimination ordering, `leadmons[0]` is initialized as an array of size `num_gb[0] * (bht->nv - st->nev)`.

https://github.com/algebraic-solving/msolve/blob/8f84271426f2e8a08ee822bf3ac76592d4c818e4/src/msolve/lifting-gb.c#L755-L770

However, `duplicate_data_mthread_trace` supposes that `leadmons[0]` is of size `num_gb[0] * (st->nvars)`.

https://github.com/algebraic-solving/msolve/blob/8f84271426f2e8a08ee822bf3ac76592d4c818e4/src/msolve/duplicate.c#L149

This causes undefined behavior on Line 162 below. On one of my machines, the line causes segmentation fault on `input_files/henrion5-qq.ms` for j between the two values, with a probability of about 5%.

https://github.com/algebraic-solving/msolve/blob/8f84271426f2e8a08ee822bf3ac76592d4c818e4/src/msolve/duplicate.c#L158-L164

This PR fixes the issue on my machine.