### PR TITLE
Fix heap overflow on computing parametrizations in non-shape-position case

### DIFF
--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -1280,7 +1280,7 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
         }
         else{
           nmod_poly_fit_length(param->coords[nvars-2-nc],
-                               param->elim->length-1 );
+                               FLINT_MAX(2, param->elim->length-1) );
           param->coords[nvars-2-nc]->length = data_bms->BMS->R1->length ;
           param->coords[nvars-2-nc]->coeffs[0] = 0;
           param->coords[nvars-2-nc]->coeffs[1] = 0;


### PR DESCRIPTION
In the following code taken from `compute_parametrizations_non_shape_position_case`:

https://github.com/algebraic-solving/msolve/blob/44fbc68b01d98ef7bf2acf845e7243fa675b892c/src/fglm/fglm_core.c#L1281-L1288

Line 1286 causes undefined behavior when `param->elim->length` is less than or equal to 2. This is in particular the case for `cyclic5-16.ms` when run with `msolve -f cyclic5-16.ms -d 4 -P 2 -l 2 -t 1 -v 2`: on one of my machines, this causes a segmentation fault.

This PR, as part of #214, fixes the issue.