### PR TITLE
Only include flint/nmod.h if we have it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,8 @@ AC_SEARCH_LIBS([fmpz_add_ui],[flint],
     [],
     [AC_MSG_ERROR([FLINT library was not found.])])
 
+AC_CHECK_HEADERS([flint/nmod.h])
+
 # check if we want OpenMP support
 AC_ARG_ENABLE([openmp],
 	[  --enable-openmp         Enable OpenMP support],

--- a/src/fglm/linalg-fglm.c
+++ b/src/fglm/linalg-fglm.c
@@ -21,7 +21,10 @@
 
 #include <stdint.h>
 #include <inttypes.h>
+
+#ifdef HAVE_FLINT_NMOD_H
 #include <flint/nmod.h>
+#endif
 
 #ifdef HAVE_AVX2
 #include <immintrin.h>


### PR DESCRIPTION
It's not present on older versions of flint.  That's okay, though, as we include it for the NMOD_RED macro, which is defined in these older versions in nmod_vec.h, which we're already (implicitly) including via nmod_poly.h.