### PR TITLE
Better lifting for grevlex GBs over QQ

### DIFF
--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1580,7 +1580,7 @@ gb_modpoly_t *core_groebner_qq(
       if(dlift->lstart != lstart){
         if(info_level){
           fprintf(stdout, "<%.2f%%>", 100* (float)MIN((dlift->lstart + 1), (*modgbsp)->ld)/(*modgbsp)->ld);
-	        fflush(stdout);
+	      fflush(stdout);
         }
         lstart = dlift->lstart;
       }


### PR DESCRIPTION
- This PR free-es dynamically some data during the lifting of GBs over QQ (once some elements of the GB have been lifted)
- This PR fixes a buffer overflow, hence fixing Issue #258

As a result, this new code saves a significant amount of memory for computing GBs over QQ (by factors increasing with the size of problems ; sometimes more than 3 times).

Issue #258  seems fixed also. 

The export functions have also been tested through Julia / AlgebraicSolving.jl under ubuntu 