### PR TITLE
Remove unnecessary fopen

### DIFF
--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -496,8 +496,14 @@ int main(int argc, char **argv){
       fprintf (stdout,"is %u\n",true_seed);
     }
 
-    FILE *fh  = fopen(files->in_file, "r");
-    FILE *bfh  = fopen(files->bin_file, "r");
+    FILE *fh = NULL;
+    FILE *bfh = NULL;
+    if (files->in_file) {
+      fh = fopen(files->in_file, "r");
+    }
+    if (files->bin_file) {
+      bfh = fopen(files->bin_file, "r");
+    }
 
     if (fh == NULL && bfh == NULL) {
       fprintf(stderr, "Input file not found.\n");


### PR DESCRIPTION
Typically, only one file is passed as `in_file` to msolve, so there's no need to do fopen on `bin_file == NULL`. I'm not sure if this is UB, but at least some runtimes are not happy about that:

```bash
filc safety error: cannot read pointer with null object (ptr = (nil),<null>).
    <runtime>: zsys_open
    <runtime>: zcall
    ../sysdeps/unix/sysv/linux/open64.c:32:19: __libc_open64
    fileops.c:188:13: __GI__IO_file_open
    fileops.c:281:12: _IO_new_file_fopen
    iofopen.c:75:7: __fopen_internal
    iofopen.c:86:10: _IO_new_fopen
    src/msolve/main.c:500:18: main
    ../sysdeps/nptl/libc_start_call_main.h:58:16: __libc_start_call_main
    ../csu/libc-start.c:161:3: __libc_start_main
    <runtime>: start_program
[2022359] filc panic: thwarted a futile attempt to violate memory safety.
```