### PR TITLE
Simplify logic and avoid overflow in `msolve.c`

### DIFF
--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -694,23 +694,22 @@ static int add_random_linear_form_to_input_system(data_gens_ff_t *gens,
 
   if (gens->field_char > 0) {
     int j = 0;
-    for (i = len_old; i < len_new; ++i) {
-      gens->random_linear_form[j] = ((int8_t)(rand()) % gens->field_char);
-
-      while (gens->random_linear_form[j] == 0) {
-        gens->random_linear_form[j] = ((int8_t)(rand()) % gens->field_char);
+    for (i = len_old; i < len_new; i++, j++) {
+      int32_t rdval = ((int8_t)(rand()) % gens->field_char);
+      while (rdval == 0) {
+        rdval = ((int8_t)(rand()) % gens->field_char);
       }
-      gens->cfs[i] = gens->random_linear_form[j];
-      j++;
+      gens->random_linear_form[j] = rdval;
+      gens->cfs[i] = rdval;
     }
   } else {
-    for (i = len_old; i < len_new; i++) {
-      int32_t rdval;
-      rdval = rand();
+    int j = 0;
+    for (i = len_old; i < len_new; i++, j++) {
+      int32_t rdval = rand();
       while (rdval == 0) {
         rdval = rand();
       }
-      gens->random_linear_form[i] = rdval;
+      gens->random_linear_form[j] = rdval;
       mpz_set_si(*(gens->mpz_cfs[2*i]), rdval);
       mpz_set_ui(*(gens->mpz_cfs[2*i + 1]), 1);
     }


### PR DESCRIPTION
Fixes #277 .

This simpler code should do the same thing as the one that was present. However I'm not sure that the one that was present had the intended behaviour, since some `sum` value was computed and never used (see #277 ).