### PR TITLE
Fix definition of some constants when sizeof(mp_limb_t)==4

### DIFF
--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -25,6 +25,7 @@
 #include<stdio.h>
 #include<stdlib.h>
 #include<string.h>
+#include<stdint.h>
 #include<unistd.h>
 #include<time.h>
 /* for timing functions */
@@ -504,7 +505,7 @@ static inline void sparse_mat_fglm_mult_vec(CF_t *res, sp_matfglm_t *mat,
   nmod_t mod;
   uint64_t pow2_precomp;
   nmod_init(&mod, (uint64_t)prime);
-  NMOD_RED(pow2_precomp, (UWORD(1) << __DOT_SPLIT_BITS), mod);
+  NMOD_RED(pow2_precomp, (UINT64_C(1) << __DOT_SPLIT_BITS), mod);
 
   _avx512_matrix_vector_product(vres, mat->dense_mat, vec, mat->dst,
                               ncols, nrows, mod, pow2_precomp, st);
@@ -512,7 +513,7 @@ static inline void sparse_mat_fglm_mult_vec(CF_t *res, sp_matfglm_t *mat,
   nmod_t mod;
   uint64_t pow2_precomp;
   nmod_init(&mod, (uint64_t)prime);
-  NMOD_RED(pow2_precomp, (UWORD(1) << __DOT_SPLIT_BITS), mod);
+  NMOD_RED(pow2_precomp, (UINT64_C(1) << __DOT_SPLIT_BITS), mod);
 
   _avx2_matrix_vector_product(vres, mat->dense_mat, vec, mat->dst,
                               ncols, nrows, mod, pow2_precomp, st);
@@ -565,7 +566,7 @@ static inline void sparse_mat_fglm_colon_mult_vec(CF_t *res, sp_matfglmcol_t *ma
   nmod_t mod;
   uint64_t pow2_precomp;
   nmod_init(&mod, (uint64_t)prime);
-  NMOD_RED(pow2_precomp, (UWORD(1) << __DOT_SPLIT_BITS), mod);
+  NMOD_RED(pow2_precomp, (UINT64_C(1) << __DOT_SPLIT_BITS), mod);
 
   _avx512_matrix_vector_product(vres, mat->dense_mat, vec, mat->dst,
                               ncols, nrows, mod, pow2_precomp, st);
@@ -573,7 +574,7 @@ static inline void sparse_mat_fglm_colon_mult_vec(CF_t *res, sp_matfglmcol_t *ma
   nmod_t mod;
   uint64_t pow2_precomp;
   nmod_init(&mod, (uint64_t)prime);
-  NMOD_RED(pow2_precomp, (UWORD(1) << __DOT_SPLIT_BITS), mod);
+  NMOD_RED(pow2_precomp, (UINT64_C(1) << __DOT_SPLIT_BITS), mod);
 
   _avx2_matrix_vector_product(vres, mat->dense_mat, vec, mat->dst,
                               ncols, nrows, mod, pow2_precomp, st);
@@ -2207,5 +2208,4 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
   /* printf ("free fglm\n"); */
   return param;
 }
-
 

--- a/src/fglm/linalg-fglm.c
+++ b/src/fglm/linalg-fglm.c
@@ -40,7 +40,7 @@
 
 // parameters for splitting
 #define __DOT_SPLIT_BITS 56
-#define __DOT_SPLIT_MASK 72057594037927935UL // (1UL << __DOT_SPLIT_BITS) - 1
+#define __DOT_SPLIT_MASK UINT64_C(72057594037927935) // (UINT64_C(1) << __DOT_SPLIT_BITS) - 1
 
 /*--------------------------------------*/
 /* non-vectorized matrix vector product */

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -912,12 +912,12 @@ static inline void normalize_nmod_param(param_t *nmod_param) {
 
     for (long i = 1; i < nmod_param->elim->length; i++) {
       nmod_param->denom->coeffs[i - 1] =
-          (i * nmod_param->elim->coeffs[i]) % prime;
+          (uint64_t)i * (uint64_t)nmod_param->elim->coeffs[i] % (uint64_t)prime;
     }
 
     for (long i = 0; i < nmod_param->elim->length - 1; i++) {
       nmod_param->denom->coeffs[i] =
-          (inv * nmod_param->denom->coeffs[i]) % prime;
+          (uint64_t)inv * (uint64_t)nmod_param->denom->coeffs[i] % (uint64_t)prime;
     }
 
     for (int j = 0; j < nmod_param->nvars - 1; j++) {


### PR DESCRIPTION
Apparently, `1UL << 56` is UB when ~`sizeof(long)==4`~ `sizeof(mp_limb_t)==4`.