### PR TITLE
Sync sort_r.h from Isaac Turner's repo

### DIFF
--- a/src/neogb/sort_r.h
+++ b/src/neogb/sort_r.h
@@ -47,11 +47,10 @@ void sort_r(void *base, size_t nel, size_t width,
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
      (defined __FreeBSD__ && !defined(qsort_r)) || defined __DragonFly__)
 #  define _SORT_R_BSD
-#elif (defined __MINGW32__ || defined __GLIBC__ || \
-       (defined (__FreeBSD__) && defined(qsort_r)))
-
+#elif (defined __GLIBC__ || (defined (__FreeBSD__) && defined(qsort_r)))
 #  define _SORT_R_LINUX
-#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__)
+#elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__ || \
+       defined __MINGW32__ || defined __MINGW64__)
 #  define _SORT_R_WINDOWS
 #  undef _SORT_R_INLINE
 #  define _SORT_R_INLINE __inline


### PR DESCRIPTION
As we are using sort_r.h from https://github.com/noporpoise/sort_r:

https://github.com/algebraic-solving/msolve/blob/261f792951bf9a396f879dad2209124ecf0d7dc3/src/neogb/sort_r.h#L21

Let's also sync the changes done in noporpoise/sort_r#17.