### PR TITLE
fix issue #303

### DIFF
--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1522,6 +1522,7 @@ restart:
                 fprintf(stdout, "[!!]");
             }
             /* nbadprimes = nprimes; */
+            nbadprimes++;
             msd->bad_primes[i] = 0;
         }
       }

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1521,7 +1521,7 @@ restart:
             if(info_level > 1){
                 fprintf(stdout, "[!!]");
             }
-            nbadprimes = nprimes;
+            /* nbadprimes = nprimes; */
             msd->bad_primes[i] = 0;
         }
       }

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -857,7 +857,8 @@ static void gb_modular_trace_application(gb_modpoly_t modgbs,
   }
   if (lml != num_gb[0]) {
       if (bs != NULL) {
-        free_basis_and_only_local_hash_table_data(&bs);
+          bad_primes[0] = 2;
+          free_basis_and_only_local_hash_table_data(&bs);
       }
       return;
   }

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1190,7 +1190,7 @@ static void ratrecon_gb(gb_modpoly_t modgbs, data_lift_t dl,
       }
     }
   }
-  if(dl->check2[modgbs->ld] == NBCHECK){
+  if(dl->check2[modgbs->ld-1] == NBCHECK){
     return;
   }
   *st_rrec += realtime()-st;

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1277,6 +1277,9 @@ gb_modpoly_t *core_groebner_qq(
         const int print_gb
         )
 {
+
+restart:
+
   *errp = 0;
 
   int32_t info_level = st->info_level;
@@ -1404,7 +1407,8 @@ gb_modpoly_t *core_groebner_qq(
       free_rrec_data(recdata2);
 
       fprintf(stdout, "Something went wrong in the learning phase, msolve restarts.");
-      return core_groebner_qq(modgbsp, bs, msd, st, errp, fc, print_gb);
+      /* return core_groebner_qq(modgbsp, bs, msd, st, errp, fc, print_gb); */
+      goto restart;
     }
     /* duplicate data for multi-threaded multi-mod computation */
     duplicate_data_mthread_gbtrace(st->nthrds, bs, st, msd->num_gb,
@@ -1535,7 +1539,8 @@ gb_modpoly_t *core_groebner_qq(
         free_rrec_data(recdata2);
         /* reset info_level to previous setting */
         st->info_level = info_level;
-        return core_groebner_qq(modgbsp, bs, msd, st, errp, fc, print_gb);
+        /* return core_groebner_qq(modgbsp, bs, msd, st, errp, fc, print_gb); */
+        goto restart;
 
       }
 

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1509,12 +1509,12 @@ restart:
       int bad = 0;
       for(int i = 0; i < nthrds/* st->nthrds */; i++){
         if(msd->bad_primes[i] == 1){
-          bad = 1;
-          if(info_level > 1){
-              fprintf(stdout, "[!]");
-          }
-          nbadprimes++;
-          msd->bad_primes[i] = 0;
+            bad = 1;
+            if(info_level > 1){
+                fprintf(stdout, "[!]");
+            }
+            nbadprimes++;
+            msd->bad_primes[i] = 0;
         }
         if(msd->bad_primes[i] == 2){
             bad = 1;

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1528,7 +1528,9 @@ restart:
 
       if(nbadprimes >= nprimes){
         if(info_level){
-          fprintf(stdout, "Too many bad primes, computation will restart\n");
+          fprintf(stdout, "\nToo many bad primes, computation will restart\n");
+          fprintf(stdout, "-------------------------------------------------\
+-----------------------------------------------------\n");
         }
         if(dlinit){
           data_lift_clear(dlift);

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -1533,6 +1533,8 @@ gb_modpoly_t *core_groebner_qq(
         gb_modpoly_without_hash_table_clear((*modgbsp));
         free_rrec_data(recdata1);
         free_rrec_data(recdata2);
+        /* reset info_level to previous setting */
+        st->info_level = info_level;
         return core_groebner_qq(modgbsp, bs, msd, st, errp, fc, print_gb);
 
       }


### PR DESCRIPTION
This draft PR is a tentative to fix issue #303.

It seems that there is an out-of-bounds access of `dl->check2` and this PR fixes it by accessing the last element of the array instead.
It already prevents the free errors of isse #303. Indeed now,

### 1773449903 no more free(): invalid pointer

`./msolve -f input_files/elim-qq.ms --random-seed 1773449903 -e 1 -g 2 -l 44 -t 1 -v 2`

```
Initial seed for pseudo-random number generator is 1773449903

--------------- INPUT DATA ---------------
#variables                       5
#equations                       4
#invalid equations               0
field characteristic             0
homogeneous input?               0
signature-based computation      0
monomial order             ELIM(1)
basis hash table resetting     OFF
linear algebra option           44
initial hash table size     131072 (2^17)
max pair selection             ALL
reduce gb                        1
#threads                         1
info level                       2
generate pbm files               0
------------------------------------------
Initial prime = 1168313717

Legend for f4 information
--------------------------------------------------------
deg       current degree of pairs selected in this round
sel       number of pairs selected in this round
pairs     total number of pairs in pair list
mat       matrix dimensions (# rows x # columns)
density   density of the matrix
new data  # new elements for basis in this round
          # zero reductions during linear algebra
time(rd)  time of the current f4 round in seconds given
          for real and cpu time
--------------------------------------------------------

deg     sel   pairs        mat          density            new data         time(rd) in sec (real|cpu)
------------------------------------------------------------------------------------------------------
  7       1       1       2 x 2          75.00%        1 new       0 zero         0.00 | 0.00         
  8       2       4       4 x 3          41.67%        1 new       1 zero         0.00 | 0.00         
  7       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  6       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  5       2       4       4 x 2          50.00%        0 new       2 zero         0.00 | 0.00         
  7       2       2       4 x 3          41.67%        1 new       1 zero         0.00 | 0.00         
  8       2       4       4 x 3          41.67%        1 new       1 zero         0.00 | 0.00         
  7       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  6       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  5       2       4       4 x 2          50.00%        0 new       2 zero         0.00 | 0.00         
  6       1       2       2 x 1         100.00%        0 new       1 zero         0.00 | 0.00         
  7       1       1       2 x 2          75.00%        1 new       0 zero         0.00 | 0.00         
  8       3       4       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  7       4       5       8 x 5          22.50%        1 new       3 zero         0.00 | 0.00         
  6       4       5       8 x 5          22.50%        1 new       3 zero         0.00 | 0.00         
  5       3       4       6 x 3          33.33%        0 new       3 zero         0.00 | 0.00         
  7       1       1       3 x 2          66.67%        0 new       1 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------
reduce final basis        7 x 9          14.29%        7 new       0 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------

---------------- TIMINGS ----------------
overall(elapsed)        0.00 sec
overall(cpu)            0.00 sec
select                  0.00 sec  10.2%
symbolic prep.          0.00 sec   2.6%
update                  0.00 sec  19.9%
convert                 0.00 sec  10.7%
linear algebra          0.00 sec   5.7%
reduce gb               0.00 sec   0.0%
-----------------------------------------

---------- COMPUTATIONAL DATA -----------
size of basis                     7
#terms in basis                   9
#pairs reduced                   40
#GM criterion                    80
#redundant elements               9
#rows reduced                    87
#zero reductions                 28
max. matrix data                  7 x 9 (14.286%)
max. symbolic hash table size  2^11
max. basis hash table size     2^16
-----------------------------------------


---------- COMPUTATIONAL DATA -----------
[6]
#polynomials to lift              6
-----------------------------------------
New prime = 1121211017

---------------- TIMINGS ----------------
multi-mod overall(elapsed)      0.00 sec
learning phase                  0.00 Gops/sec
application phase               0.00 Gops/sec
-----------------------------------------

multi-modular steps
------------------------------------------------------------------------------------------------------
{1}{2}<100.00%><33.33%> 
------------------------------------------------------------------------------------------------------


---------- COMPUTATIONAL DATA -----------
Max coeff. bitsize                1
#primes                           3
#bad primes                       0
-----------------------------------------

---------------- TIMINGS ----------------
CRT     (elapsed)               0.00 sec
ratrecon(elapsed)               0.00 sec
-----------------------------------------
#Reduced Groebner basis data
#---
#field characteristic: 0
#variable order:       w, x, y, z
#monomial order:       graded reverse lexicographical
#length of basis:      6 elements sorted by increasing leading monomials
#---
[w*y^3-x*z^3, 
x^4, 
w*x^3, 
w^2*x^2, 
w^3*x, 
w^4]:


------------------------------------------------------------------------------------
msolve overall time           0.01 sec (elapsed) /  0.01 sec (cpu)
------------------------------------------------------------------------------------
```

### 1773457808 no more double free or corruption

`./msolve -f input_files/elim-qq.ms --random-seed 1773457808 -e 1 -g 2 -l 44 -t 1 -v 2`

```
Initial seed for pseudo-random number generator is 1773457808

--------------- INPUT DATA ---------------
#variables                       5
#equations                       4
#invalid equations               0
field characteristic             0
homogeneous input?               0
signature-based computation      0
monomial order             ELIM(1)
basis hash table resetting     OFF
linear algebra option           44
initial hash table size     131072 (2^17)
max pair selection             ALL
reduce gb                        1
#threads                         1
info level                       2
generate pbm files               0
------------------------------------------
Initial prime = 1224200387

Legend for f4 information
--------------------------------------------------------
deg       current degree of pairs selected in this round
sel       number of pairs selected in this round
pairs     total number of pairs in pair list
mat       matrix dimensions (# rows x # columns)
density   density of the matrix
new data  # new elements for basis in this round
          # zero reductions during linear algebra
time(rd)  time of the current f4 round in seconds given
          for real and cpu time
--------------------------------------------------------

deg     sel   pairs        mat          density            new data         time(rd) in sec (real|cpu)
------------------------------------------------------------------------------------------------------
  7       1       1       2 x 2          75.00%        1 new       0 zero         0.00 | 0.00         
  8       2       4       4 x 3          41.67%        1 new       1 zero         0.00 | 0.00         
  7       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  6       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  5       2       4       4 x 2          50.00%        0 new       2 zero         0.00 | 0.00         
  7       2       2       4 x 3          41.67%        1 new       1 zero         0.00 | 0.00         
  8       2       4       4 x 3          41.67%        1 new       1 zero         0.00 | 0.00         
  7       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  6       3       5       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  5       2       4       4 x 2          50.00%        0 new       2 zero         0.00 | 0.00         
  6       1       2       2 x 1         100.00%        0 new       1 zero         0.00 | 0.00         
  7       1       1       2 x 2          75.00%        1 new       0 zero         0.00 | 0.00         
  8       3       4       6 x 4          29.17%        1 new       2 zero         0.00 | 0.00         
  7       4       5       8 x 5          22.50%        1 new       3 zero         0.00 | 0.00         
  6       4       5       8 x 5          22.50%        1 new       3 zero         0.00 | 0.00         
  5       3       4       6 x 3          33.33%        0 new       3 zero         0.00 | 0.00         
  7       1       1       3 x 2          66.67%        0 new       1 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------
reduce final basis        7 x 9          14.29%        7 new       0 zero         0.00 | 0.00         
------------------------------------------------------------------------------------------------------

---------------- TIMINGS ----------------
overall(elapsed)        0.00 sec
overall(cpu)            0.00 sec
select                  0.00 sec   9.3%
symbolic prep.          0.00 sec   2.3%
update                  0.00 sec  20.6%
convert                 0.00 sec   9.1%
linear algebra          0.00 sec   6.3%
reduce gb               0.00 sec   0.0%
-----------------------------------------

---------- COMPUTATIONAL DATA -----------
size of basis                     7
#terms in basis                   9
#pairs reduced                   40
#GM criterion                    80
#redundant elements               9
#rows reduced                    87
#zero reductions                 28
max. matrix data                  7 x 9 (14.286%)
max. symbolic hash table size  2^11
max. basis hash table size     2^16
-----------------------------------------


---------- COMPUTATIONAL DATA -----------
[6]
#polynomials to lift              6
-----------------------------------------
New prime = 1116403859

---------------- TIMINGS ----------------
multi-mod overall(elapsed)      0.00 sec
learning phase                  0.00 Gops/sec
application phase               0.00 Gops/sec
-----------------------------------------

multi-modular steps
------------------------------------------------------------------------------------------------------
{1}{2}<100.00%><33.33%> 
------------------------------------------------------------------------------------------------------


---------- COMPUTATIONAL DATA -----------
Max coeff. bitsize                1
#primes                           3
#bad primes                       0
-----------------------------------------

---------------- TIMINGS ----------------
CRT     (elapsed)               0.00 sec
ratrecon(elapsed)               0.00 sec
-----------------------------------------
#Reduced Groebner basis data
#---
#field characteristic: 0
#variable order:       w, x, y, z
#monomial order:       graded reverse lexicographical
#length of basis:      6 elements sorted by increasing leading monomials
#---
[w*y^3-x*z^3, 
x^4, 
w*x^3, 
w^2*x^2, 
w^3*x, 
w^4]:


------------------------------------------------------------------------------------
msolve overall time           0.01 sec (elapsed) /  0.01 sec (cpu)
------------------------------------------------------------------------------------
```

