### PR TITLE
Fix typo/bug in duplicate.c

### DIFF
--- a/src/msolve/duplicate.c
+++ b/src/msolve/duplicate.c
@@ -67,7 +67,7 @@ static inline void duplicate_tracer(
             /* non-redundant lead mon. as short divmask */
             btrace[i]->lm   = (sdm_t *)calloc((unsigned long)btrace[0]->lml,
                     sizeof(sdm_t));
-            memcpy(btrace[0]->lm, btrace[i]->lm,
+            memcpy(btrace[i]->lm, btrace[0]->lm,
                     (unsigned long)btrace[0]->lml * sizeof(sdm_t));
 
             /* array of trace data per F4 round */


### PR DESCRIPTION
This PR answers Issue #286 and fixes it. Actually, this typo could create bugs in some execution for some bad chosen primes. 
Many thanks to @wegank 