### PR TITLE
adds #define for print streams: output, verbose and error

### DIFF
--- a/src/crt/mpq_reconstruct.c
+++ b/src/crt/mpq_reconstruct.c
@@ -25,6 +25,7 @@
 **/
 
 #include <gmp.h>
+#include "../msolve/streams.h"
 
 /* #define ROT(u,v,t)                                            \ */
 /*   do { mpz _t = *u; *u = *v; *v = *t; *t = _t; } while (0); */
@@ -67,7 +68,7 @@ _mpq_reconstruct_mpz_2(mpz_t n, mpz_t d,
     /* if (fmpz_cmpabs(n, N) <= 0) */
     /* { */
     /*     fmpz_one(d); */
-    /*     fprintf(stderr, "ici?\n"); */
+    /*     fprintf(ERRSTREAM, "ici?\n"); */
     /*     return 1; */
     /* } */
 
@@ -159,7 +160,7 @@ int mpq_reconstruct_mpz(mpq_t *res, mpz_t a, const mpz_t m)
   }
   else{
     while(mpz_cmp_ui(a, 0) < 0){
-      //      mpz_fprint(stderr, a); fprintf(stderr, "\n");
+      //      mpz_fprint(ERRSTREAM, a); fprintf(ERRSTREAM, "\n");
       mpz_add(a, a, m);
     }
     int b = _mpq_reconstruct_mpz(mpq_numref(*res),

--- a/src/crt/mpz_CRT_ui.c
+++ b/src/crt/mpz_CRT_ui.c
@@ -25,6 +25,7 @@ This implementation is a (very) slight modification of the functions in FLINT.
  **/
 
 #include "ulong_extras.h"
+#include "../msolve/streams.h"
 
 void
 _mpz_CRT_ui_precomp(mpz_t out, const mpz_t r1, const mpz_t m1, uint64_t r2,
@@ -77,7 +78,7 @@ void mpz_CRT_ui(mpz_t out, const mpz_t r1, const mpz_t m1,
 
   if (c == 0)
     {
-      fprintf(stderr, "Exception (fmpz_CRT_ui). m1 not invertible modulo m2.\n");
+      fprintf(ERRSTREAM, "Exception (fmpz_CRT_ui). m1 not invertible modulo m2.\n");
       exit(1);
     }
 

--- a/src/fglm/berlekamp_massey.c
+++ b/src/fglm/berlekamp_massey.c
@@ -36,7 +36,7 @@
 //#include "nmod_poly.h"
 //#include "mpn_extras.h"
 
-
+#include "../msolve/streams.h"
 
 /*
 typedef struct {
@@ -205,7 +205,7 @@ int nmod_em_gcd(nmod_berlekamp_massey_t B){
     }
   B->npoints = queue_hi;
 
-  //  nmod_poly_fprint_pretty(stderr, B->R0, "x");fprintf(stderr, "\n");
+  //  nmod_poly_fprint_pretty(ERRSTREAM, B->R0, "x");fprintf(ERRSTREAM, "\n");
 
   /* Ri = Ri * x^queue_len + Vi*rt */
   //R0 vaut x^queue_len-1 avec queue_len = 2*dim - 1
@@ -267,11 +267,11 @@ int nmod_em_gcd(nmod_berlekamp_massey_t B){
       nmod_poly_init_mod(r1, B->V1->mod);
       nmod_poly_init_mod(t0, B->V1->mod);
       nmod_poly_init_mod(t1, B->V1->mod);
-      
+
       nmod_poly_shift_right(r0, B->R0, k);
       nmod_poly_shift_right(r1, B->R1, k);
       sgnM = nmod_poly_hgcd(m11, m12, m21, m22, t0, t1, r0, r1);
-      
+
       /* multiply [[V0 R0] [V1 R1]] by M^(-1) on the left */
       nmod_poly_mul(B->rt, m22, B->V0);
       nmod_poly_mul(B->qt, m12, B->V1);
@@ -283,7 +283,7 @@ int nmod_em_gcd(nmod_berlekamp_massey_t B){
         : nmod_poly_sub(r1, B->qt, B->rt);
       nmod_poly_swap(B->V0, r0);
       nmod_poly_swap(B->V1, r1);
-      
+
       nmod_poly_mul(B->rt, m22, B->R0);
       nmod_poly_mul(B->qt, m12, B->R1);
       sgnM > 0 ? nmod_poly_sub(r0, B->rt, B->qt)
@@ -294,7 +294,7 @@ int nmod_em_gcd(nmod_berlekamp_massey_t B){
         : nmod_poly_sub(r1, B->qt, B->rt);
       nmod_poly_swap(B->R0, r0);
       nmod_poly_swap(B->R1, r1);
-      
+
       nmod_poly_clear(m11);
       nmod_poly_clear(m12);
       nmod_poly_clear(m21);
@@ -304,13 +304,13 @@ int nmod_em_gcd(nmod_berlekamp_massey_t B){
       nmod_poly_clear(t0);
       nmod_poly_clear(t1);
     }
-  
+
   FLINT_ASSERT(nmod_poly_degree(B->V1) >= 0);
   FLINT_ASSERT(2*nmod_poly_degree(B->V1) <= B->npoints);
   FLINT_ASSERT(2*nmod_poly_degree(B->R0) >= B->npoints);
   FLINT_ASSERT(2*nmod_poly_degree(B->R1) <  B->npoints);
 
-  
+
   return 1;
 }
 
@@ -330,7 +330,7 @@ int nmod_em_gcd_preinstantiated(nmod_berlekamp_massey_t B, long shift){
   /*   } */
   B->npoints = queue_hi;
 
-  //  nmod_poly_fprint_pretty(stderr, B->R0, "x");fprintf(stderr, "\n");
+  //  nmod_poly_fprint_pretty(ERRSTREAM, B->R0, "x");fprintf(ERRSTREAM, "\n");
 
   /* Ri = Ri * x^queue_len + Vi*rt */
   //R0 vaut x^queue_len-1 avec queue_len = 2*dim - 1
@@ -392,11 +392,11 @@ int nmod_em_gcd_preinstantiated(nmod_berlekamp_massey_t B, long shift){
       nmod_poly_init_mod(r1, B->V1->mod);
       nmod_poly_init_mod(t0, B->V1->mod);
       nmod_poly_init_mod(t1, B->V1->mod);
-      
+
       nmod_poly_shift_right(r0, B->R0, k);
       nmod_poly_shift_right(r1, B->R1, k);
       sgnM = nmod_poly_hgcd(m11, m12, m21, m22, t0, t1, r0, r1);
-      
+
       /* multiply [[V0 R0] [V1 R1]] by M^(-1) on the left */
       nmod_poly_mul(B->rt, m22, B->V0);
       nmod_poly_mul(B->qt, m12, B->V1);
@@ -408,7 +408,7 @@ int nmod_em_gcd_preinstantiated(nmod_berlekamp_massey_t B, long shift){
         : nmod_poly_sub(r1, B->qt, B->rt);
       nmod_poly_swap(B->V0, r0);
       nmod_poly_swap(B->V1, r1);
-      
+
       nmod_poly_mul(B->rt, m22, B->R0);
       nmod_poly_mul(B->qt, m12, B->R1);
       sgnM > 0 ? nmod_poly_sub(r0, B->rt, B->qt)
@@ -419,7 +419,7 @@ int nmod_em_gcd_preinstantiated(nmod_berlekamp_massey_t B, long shift){
         : nmod_poly_sub(r1, B->qt, B->rt);
       nmod_poly_swap(B->R0, r0);
       nmod_poly_swap(B->R1, r1);
-      
+
       nmod_poly_clear(m11);
       nmod_poly_clear(m12);
       nmod_poly_clear(m21);
@@ -429,12 +429,12 @@ int nmod_em_gcd_preinstantiated(nmod_berlekamp_massey_t B, long shift){
       nmod_poly_clear(t0);
       nmod_poly_clear(t1);
     }
-  
+
   FLINT_ASSERT(nmod_poly_degree(B->V1) >= 0);
   FLINT_ASSERT(2*nmod_poly_degree(B->V1) <= B->npoints);
   FLINT_ASSERT(2*nmod_poly_degree(B->R0) >= B->npoints);
   FLINT_ASSERT(2*nmod_poly_degree(B->R1) <  B->npoints);
-  
+
   return 1;
 }
 
@@ -465,12 +465,12 @@ int nmod_berlekamp_massey_reduce_modif(
                                       B->points->coeffs[queue_lo + i]);
     }
     B->npoints = queue_hi;
-    //    fprintf(stderr, "queue_len = %ld, queue_hi = %ld, queue_lo=%ld\n", queue_len, queue_hi, queue_lo);
-    //    nmod_poly_fprint_pretty(stderr, B->R0, "x");fprintf(stderr, "\n");
+    //    fprintf(ERRSTREAM, "queue_len = %ld, queue_hi = %ld, queue_lo=%ld\n", queue_len, queue_hi, queue_lo);
+    //    nmod_poly_fprint_pretty(ERRSTREAM, B->R0, "x");fprintf(ERRSTREAM, "\n");
     /* Ri = Ri * x^queue_len + Vi*rt */
     //R0 vaut x^queue_len
     nmod_poly_shift_left(B->R0, B->R0, queue_len);
-    //    nmod_poly_fprint_pretty(stderr, B->R0, "x");fprintf(stderr, "\n");
+    //    nmod_poly_fprint_pretty(ERRSTREAM, B->R0, "x");fprintf(ERRSTREAM, "\n");
     //done.
 
     nmod_poly_mul(B->qt, B->V0, B->rt);

--- a/src/fglm/data_fglm.c
+++ b/src/fglm/data_fglm.c
@@ -25,6 +25,7 @@
 #include <flint/nmod_poly.h>
 #include <flint/nmod_poly_factor.h>
 #include <flint/ulong_extras.h>
+#include "../msolve/streams.h"
 
 
 static inline void free_sp_mat_fglm(sp_matfglm_t *mat){
@@ -44,22 +45,22 @@ static inline fglm_data_t *allocate_fglm_data(szmat_t nrows, szmat_t ncols, szma
   szmat_t block_size = nvars; //block size in data->res
 
   if(posix_memalign((void **)&data->vecinit, 32, ncols*sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
 
   if(posix_memalign((void **)&data->res, 32, 2 * block_size * ncols * sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
 
   if(posix_memalign((void **)&data->vecmult, 32, nrows*sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
 
   if(posix_memalign((void **)&data->vvec, 32, ncols*sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
   data->pts = calloc(ncols * 2, sizeof(mp_limb_t));
@@ -148,7 +149,7 @@ static inline void display_fglm_colon_matrix(FILE *file, sp_matfglmcol_t *matrix
 static inline param_t *allocate_fglm_param(mp_limb_t prime, long nvars){
   param_t *param = malloc(sizeof(param_t));
   if(param==NULL){
-    fprintf(stderr, "Pb when calling malloc to allocate param_t\n");
+    fprintf(ERRSTREAM, "Pb when calling malloc to allocate param_t\n");
     exit(1);
     return param;
   }

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -30,6 +30,7 @@
 #include<time.h>
 /* for timing functions */
 #include "../neogb/tools.h"
+#include "../msolve/streams.h"
 
 #ifdef _OPENMP
 #include<omp.h>
@@ -210,7 +211,7 @@ static int invert_hankel_matrix(fglm_bms_data_t *data_bms, szmat_t dim){
 
     nmod_em_gcd(data_bms->BMS);
     if(data_bms->BMS->R1->length-1 < dim-1 && dim > 1){
-        fprintf(stderr, "Singular matrix\n");
+        fprintf(ERRSTREAM, "Singular matrix\n");
         return 0;
     }
 
@@ -236,8 +237,8 @@ static int invert_hankel_matrix(fglm_bms_data_t *data_bms, szmat_t dim){
 
     }
     else{//V1(0) = 0
-        fprintf(stderr, "Warning: this part of the code has not been ");
-        fprintf(stderr, "tested intensively\n");
+        fprintf(ERRSTREAM, "Warning: this part of the code has not been ");
+        fprintf(ERRSTREAM, "tested intensively\n");
         nmod_poly_one(data_bms->BMS->R0);
         nmod_poly_zero(data_bms->BMS->R1);
         nmod_poly_zero(data_bms->BMS->V0);
@@ -280,12 +281,12 @@ static int invert_hankel_matrix(fglm_bms_data_t *data_bms, szmat_t dim){
             inv = n_invmod(data_bms->BMS->R1->coeffs[data_bms->BMS->R1->length-1],
                            (data_bms->BMS->R1->mod).n);
             nmod_poly_scalar_mul_nmod(data_bms->Z2, data_bms->BMS->V1, inv);
-            /* fprintf(stderr, "Something should be checked\n"); */
+            /* fprintf(ERRSTREAM, "Something should be checked\n"); */
             return 1;
         }
         else{
-            fprintf(stderr, "Warning: this part of the code has not been ");
-            fprintf(stderr, "tested intensively at all\n");
+            fprintf(ERRSTREAM, "Warning: this part of the code has not been ");
+            fprintf(ERRSTREAM, "tested intensively at all\n");
             nmod_poly_one(data_bms->BMS->R0);
             nmod_poly_zero(data_bms->BMS->R1);
             nmod_poly_zero(data_bms->BMS->V0);
@@ -303,7 +304,7 @@ static int invert_hankel_matrix(fglm_bms_data_t *data_bms, szmat_t dim){
             nmod_poly_set_coeff_ui(data_bms->BMS->rt, 2*dim,
                                    (data_bms->BMS->R1->mod).n-1);
             nmod_poly_print_pretty (data_bms->BMS->rt,"x");
-            printf("\n");
+            fprintf(ERRSTREAM, "\n");
 
             nmod_em_gcd_preinstantiated(data_bms->BMS, 0);//B->rt is pre-instantied
 
@@ -332,11 +333,11 @@ static int invert_hankel_matrix(fglm_bms_data_t *data_bms, szmat_t dim){
                 inv = n_invmod(data_bms->BMS->R1->coeffs[data_bms->BMS->R1->length-1],
                                (data_bms->BMS->R1->mod).n);
                 nmod_poly_scalar_mul_nmod(data_bms->Z2, data_bms->BMS->V1, inv);
-                /* fprintf(stderr, "Something should be checked\n"); */
+                /* fprintf(ERRSTREAM, "Something should be checked\n"); */
                 return 1;
             }
             else{
-                fprintf(stderr, "There should be a bug here (invert_hankel)\n");
+                fprintf(ERRSTREAM, "There should be a bug here (invert_hankel)\n");
                 return 0;
             }
         }
@@ -362,10 +363,10 @@ static inline void solve_hankel(fglm_bms_data_t *data_bms,
   }
 
   #if DEBUGFGLM > 0
-  fprintf(stdout, "\n ncoord = %d\n", ncoord);
-  fprintf(stdout, "V = ");
-  nmod_poly_fprint_pretty(stdout, data_bms->V, "x");
-  fprintf(stdout, "\n");
+  fprintf(VERBSTREAM, "\n ncoord = %d\n", ncoord);
+  fprintf(VERBSTREAM, "V = ");
+  nmod_poly_fprint_pretty(VERBSTREAM, data_bms->V, "x");
+  fprintf(VERBSTREAM, "\n");
   #endif
 
   mirror_poly_inplace(data_bms->V);
@@ -524,11 +525,11 @@ static inline void print_vec(FILE *file, CF_t *vec, szmat_t len){
 static inline void mynmod_berlekamp_massey_print(const nmod_berlekamp_massey_t B)
 {
   slong i;
-  nmod_poly_fprint_pretty(stderr, B->V1, "x");
-  fprintf(stderr, ", ");
+  nmod_poly_fprint_pretty(ERRSTREAM, B->V1, "x");
+  fprintf(ERRSTREAM, ", ");
   for (i = 0; i < B->points->length; i++)
     {
-      fprintf(stderr, " %lu", B->points->coeffs[i]);
+      fprintf(ERRSTREAM, " %lu", B->points->coeffs[i]);
     }
 }
 
@@ -571,7 +572,7 @@ static void generate_matrix_sequence(sp_matfglm_t *matxn, fglm_data_t *data,
   /* allocates random matrix */
   CF_t *Rmat ALIGNED32;
   if(posix_memalign((void **)&Rmat, 32, BL*ncols*sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
   memset(Rmat, 0, (ncols)*sizeof(CF_t));
@@ -586,7 +587,7 @@ static void generate_matrix_sequence(sp_matfglm_t *matxn, fglm_data_t *data,
   /* allocates result matrix (matxn * Rmat) */
   CF_t *res ALIGNED32;
   if(posix_memalign((void **)&res, 32, BL*ncols*sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
   memset(res, 0, BL*ncols*sizeof(CF_t));
@@ -594,7 +595,7 @@ static void generate_matrix_sequence(sp_matfglm_t *matxn, fglm_data_t *data,
   /* allocates temporary matrix */
   CF_t *tres ALIGNED32;
   if(posix_memalign((void **)&tres, 32, nrows*ncols*sizeof(CF_t))){
-    fprintf(stderr, "posix_memalign failed\n");
+    fprintf(ERRSTREAM, "posix_memalign failed\n");
     exit(1);
   }
   memset(tres, 0, nrows*ncols*sizeof(CF_t));
@@ -609,7 +610,7 @@ static void generate_matrix_sequence(sp_matfglm_t *matxn, fglm_data_t *data,
                        RED_32,
                        RED_64);
 #else
-    fprintf(stderr, "Not implemented yet\n");
+    fprintf(ERRSTREAM, "Not implemented yet\n");
     exit(1);
 #endif
   }
@@ -641,7 +642,7 @@ static void generate_sequence_verif(sp_matfglm_t *matrix, fglm_data_t * data,
                              data->vecinit, data->vecmult,
                              prime, st);
 #if DEBUGFGLM > 1
-    print_vec(stderr, data->vvec, matrix->ncols);
+    print_vec(ERRSTREAM, data->vvec, matrix->ncols);
 #endif
 
 
@@ -661,12 +662,12 @@ static void generate_sequence_verif(sp_matfglm_t *matrix, fglm_data_t * data,
     }
 
 #if DEBUGFGLM > 1
-    print_vec(stdout, data->res, 2*block_size * matrix->ncols);
+    print_vec(VERBSTREAM, data->res, 2*block_size * matrix->ncols);
 #endif
 
 #if DEBUGFGLM > 2
-    fprintf(stderr, "res = ");
-    print_vec(stdout, data->res+i*matrix->ncols, matrix->ncols);
+    fprintf(ERRSTREAM, "res = ");
+    print_vec(VERBSTREAM, data->res+i*matrix->ncols, matrix->ncols);
 #endif
   }
   for(szmat_t i = matrix->ncols; i < 2*matrix->ncols; i++){
@@ -674,7 +675,7 @@ static void generate_sequence_verif(sp_matfglm_t *matrix, fglm_data_t * data,
                              data->vecinit, data->vecmult,
                              prime, st);
 #if DEBUGFGLM > 1
-    print_vec(stderr, data->vvec, matrix->ncols);
+    print_vec(ERRSTREAM, data->vvec, matrix->ncols);
 #endif
 
 
@@ -684,12 +685,12 @@ static void generate_sequence_verif(sp_matfglm_t *matrix, fglm_data_t * data,
     data->res[i*block_size] = data->vecinit[0];
 
 #if DEBUGFGLM > 1
-    print_vec(stdout, data->res, 2*block_size * matrix->ncols);
+    print_vec(VERBSTREAM, data->res, 2*block_size * matrix->ncols);
 #endif
 
 #if DEBUGFGLM > 2
-    fprintf(stderr, "res = ");
-    print_vec(stdout, data->res+i*matrix->ncols, matrix->ncols);
+    fprintf(ERRSTREAM, "res = ");
+    print_vec(VERBSTREAM, data->res+i*matrix->ncols, matrix->ncols);
 #endif
   }
 
@@ -852,7 +853,7 @@ static void set_param_linear_vars(param_t *param,
   }
 
 #if DEBUGFGLM >0
-  display_fglm_param(stderr, param);
+  display_fglm_param(ERRSTREAM, param);
 #endif
 }
 
@@ -872,8 +873,8 @@ static int compute_parametrizations(param_t *param,
   if(nlins != nvars){
     b = invert_hankel_matrix(data_bms, dim);
 #if DEBUGFGLM > 0
-    fprintf(stdout, "Z1 = "); nmod_poly_fprint_pretty(stdout, data_bms->Z1, "x");fprintf(stdout, "\n");
-    fprintf(stdout, "Z2 = "); nmod_poly_fprint_pretty(stdout, data_bms->Z2, "x");fprintf(stdout, "\n");
+    fprintf(VERBSTREAM, "Z1 = "); nmod_poly_fprint_pretty(VERBSTREAM, data_bms->Z1, "x");fprintf(VERBSTREAM, "\n");
+    fprintf(VERBSTREAM, "Z2 = "); nmod_poly_fprint_pretty(VERBSTREAM, data_bms->Z2, "x");fprintf(VERBSTREAM, "\n");
 #endif
   }
 
@@ -893,8 +894,8 @@ static int compute_parametrizations(param_t *param,
                       param->elim);
 
 #if DEBUGFGLM > 0
-        nmod_poly_fprint_pretty(stdout, param->coords[nvars-2-nc], "X");
-        fprintf(stdout, "\n");
+        nmod_poly_fprint_pretty(VERBSTREAM, param->coords[nvars-2-nc], "X");
+        fprintf(VERBSTREAM, "\n");
 #endif
 
       }
@@ -916,9 +917,9 @@ static int compute_parametrizations(param_t *param,
     set_param_linear_vars(param, nlins, linvars, lineqs, nvars);
 
 #if DEBUGFGLM > 0
-    fprintf(stderr, "PARAM = ");
-    display_fglm_param_maple(stderr, param);
-    fprintf(stderr, "\n");
+    fprintf(ERRSTREAM, "PARAM = ");
+    display_fglm_param_maple(ERRSTREAM, param);
+    fprintf(ERRSTREAM, "\n");
 #endif
     return 1;
   }
@@ -1057,10 +1058,10 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
   if (invert_table_polynomial (param, data, data_bms, block_size,
                                prime, 0, 0)) {
 #if DEBUGFGLM > 0
-    fprintf (stdout,"C1=");
-    nmod_poly_fprint_pretty (stdout, data_bms->Z1, "x"); fprintf (stdout,"\n");
-    fprintf(stdout, "invC1=");
-    nmod_poly_fprint_pretty (stdout, data_bms->Z2, "x"); fprintf (stdout,"\n");
+    fprintf (VERBSTREAM,"C1=");
+    nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z1, "x"); fprintf (VERBSTREAM,"\n");
+    fprintf(VERBSTREAM, "invC1=");
+    nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z2, "x"); fprintf (VERBSTREAM,"\n");
 #endif
 
     long dec = 0;
@@ -1083,8 +1084,8 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
         }
 
 #if DEBUGFGLM > 0
-        nmod_poly_fprint_pretty(stdout, param->coords[nvars-2-nc], "X");
-        fprintf(stdout, "\n");
+        nmod_poly_fprint_pretty(VERBSTREAM, param->coords[nvars-2-nc], "X");
+        fprintf(VERBSTREAM, "\n");
 #endif
       }
       else{
@@ -1117,10 +1118,10 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
           invert_table_polynomial (param, data, data_bms, block_size,
                                    prime, nc+1-dec, lambda);
 #if DEBUGFGLM > 1
-          fprintf (stdout,"C2=");
-          nmod_poly_fprint_pretty (stdout, data_bms->Z1, "x"); fprintf (stdout,"\n");
-          fprintf(stdout, "invC2=");
-          nmod_poly_fprint_pretty (stdout, data_bms->Z2, "x"); fprintf (stdout,"\n");
+          fprintf (VERBSTREAM,"C2=");
+          nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z1, "x"); fprintf (VERBSTREAM,"\n");
+          fprintf(VERBSTREAM, "invC2=");
+          nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z2, "x"); fprintf (VERBSTREAM,"\n");
 #endif
 
           divide_table_polynomials(param,data,data_bms, dimquot, block_size,
@@ -1128,8 +1129,8 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
           nmod_poly_neg(data_bms->BMS->R1, data_bms->BMS->R1);
 
 #if DEBUGFGLM > 1
-          nmod_poly_fprint_pretty(stdout, data_bms->BMS->R1, "X");
-          fprintf(stdout, "\n");
+          nmod_poly_fprint_pretty(VERBSTREAM, data_bms->BMS->R1, "X");
+          fprintf(VERBSTREAM, "\n");
 #endif
 
           if (! nmod_poly_equal (param->coords[nvars-2-nc],data_bms->BMS->R1)) {
@@ -1165,7 +1166,7 @@ int compute_parametrizations_non_shape_position_case(param_t *param,
     set_param_linear_vars(param, nlins, linvars, lineqs, nvars);
 
 #if DEBUGFGLM>0
-    display_fglm_param_maple(stderr, param);
+    display_fglm_param_maple(ERRSTREAM, param);
 #endif
 
     return nvars-1-nr_fail_param;
@@ -1190,10 +1191,10 @@ static int compute_parametrizations_colon(param_t *param,
   if (invert_table_polynomial (param, data, data_bms, block_size,
                                prime, 0, 0)) {
 #if DEBUGFGLM > 0
-    fprintf (stdout,"C1=");
-    nmod_poly_fprint_pretty (stdout, data_bms->Z1, "x"); fprintf (stdout,"\n");
-    fprintf(stdout, "invC1=");
-    nmod_poly_fprint_pretty (stdout, data_bms->Z2, "x"); fprintf (stdout,"\n");
+    fprintf (VERBSTREAM,"C1=");
+    nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z1, "x"); fprintf (VERBSTREAM,"\n");
+    fprintf(VERBSTREAM, "invC1=");
+    nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z2, "x"); fprintf (VERBSTREAM,"\n");
 #endif
     long dec = 0;
     for(long nc = 0; nc < nvars - 1 ; nc++){
@@ -1202,8 +1203,8 @@ static int compute_parametrizations_colon(param_t *param,
 				       nc + 1-dec,nvars,0);
         nmod_poly_neg(param->coords[nvars-2-nc], data_bms->BMS->R1);
 #if DEBUGFGLM > 0
-        nmod_poly_fprint_pretty(stdout, param->coords[nvars-2-nc], "X");
-        fprintf(stdout, "\n");
+        nmod_poly_fprint_pretty(VERBSTREAM, param->coords[nvars-2-nc], "X");
+        fprintf(VERBSTREAM, "\n");
 #endif
       }
       else{
@@ -1224,10 +1225,10 @@ static int compute_parametrizations_colon(param_t *param,
           invert_table_polynomial (param, data, data_bms, block_size,
                                    prime, nc+1-dec, lambda);
 #if DEBUGFGLM > 1
-          fprintf (stdout,"C2=");
-          nmod_poly_fprint_pretty (stdout, data_bms->Z1, "x"); fprintf (stdout,"\n");
-          fprintf(stdout, "invC2=");
-          nmod_poly_fprint_pretty (stdout, data_bms->Z2, "x"); fprintf (stdout,"\n");
+          fprintf (VERBSTREAM,"C2=");
+          nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z1, "x"); fprintf (VERBSTREAM,"\n");
+          fprintf(VERBSTREAM, "invC2=");
+          nmod_poly_fprint_pretty (VERBSTREAM, data_bms->Z2, "x"); fprintf (VERBSTREAM,"\n");
 #endif
 
           divide_table_polynomials_colon(param,data,data_bms, block_size,
@@ -1235,8 +1236,8 @@ static int compute_parametrizations_colon(param_t *param,
           nmod_poly_neg(data_bms->BMS->R1, data_bms->BMS->R1);
 
 #if DEBUGFGLM > 1
-          nmod_poly_fprint_pretty(stdout, data_bms->BMS->R1, "X");
-          fprintf(stdout, "\n");
+          nmod_poly_fprint_pretty(VERBSTREAM, data_bms->BMS->R1, "X");
+          fprintf(VERBSTREAM, "\n");
 #endif
           if (! nmod_poly_equal (param->coords[nvars-2-nc],data_bms->BMS->R1)) {
             if (nr_fail_param == -1) {
@@ -1265,7 +1266,7 @@ static int compute_parametrizations_colon(param_t *param,
     set_param_linear_vars(param, nlins, linvars, lineqs, nvars);
 
 #if DEBUGFGLM>0
-    display_fglm_param_maple(stderr, param);
+    display_fglm_param_maple(ERRSTREAM, param);
 #endif
 
     return nvars-1-nr_fail_param;
@@ -1333,7 +1334,7 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
                                       int *success,
                                       md_t *st){
 #if DEBUGFGLM > 0
-  fprintf(stderr, "prime = %u\n", prime);
+  fprintf(ERRSTREAM, "prime = %u\n", prime);
 #endif
 
 #if DEBUGFGLM >= 1
@@ -1344,8 +1345,8 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 
   /* 1147878294 */
   if(prime>=1518500213){
-    fprintf(stderr, "Prime %u is too large.\n", prime);
-    fprintf(stderr, "One needs to use updated linear algebra fglm functions\n");
+    fprintf(ERRSTREAM, "Prime %u is too large.\n", prime);
+    fprintf(ERRSTREAM, "One needs to use updated linear algebra fglm functions\n");
     return NULL;
   }
 
@@ -1360,10 +1361,10 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   initialize_fglm_data(matrix, *bdata, prime, sz, block_size);
 
   /* if(info_level){ */
-  /*   fprintf(stderr, "[%u, %u], Dense / Total = %.2f%%\n", */
+  /*   fprintf(ERRSTREAM, "[%u, %u], Dense / Total = %.2f%%\n", */
   /*           matrix->ncols, matrix->nrows, */
   /*           100*((double)matrix->nrows / (double)matrix->ncols)); */
-  /*   fprintf(stderr, "Density of non-trivial part %.2f%%\n", */
+  /*   fprintf(ERRSTREAM, "Density of non-trivial part %.2f%%\n", */
   /*           100-100*(float)nb/(float)sz); */
   /* } */
 
@@ -1373,20 +1374,20 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   double cst_fglm = cputime();
 
 #if BLOCKWIED > 0
-  fprintf(stderr, "Starts computation of matrix sequence\n");
+  fprintf(ERRSTREAM, "Starts computation of matrix sequence\n");
   double st0 = omp_get_wtime();
   generate_matrix_sequence(matrix, *bdata, block_size, dimquot,
                            squvars, linvars, nvars, prime, st);
   double et0 = omp_get_wtime() - st0;
-  fprintf(stderr, "Matrix sequence computed\n");
-  fprintf(stderr, "Elapsed time : %.2f\n", et0);
-  fprintf(stderr, "Implementation to be completed\n");
+  fprintf(ERRSTREAM, "Matrix sequence computed\n");
+  fprintf(ERRSTREAM, "Elapsed time : %.2f\n", et0);
+  fprintf(ERRSTREAM, "Implementation to be completed\n");
   exit(1);
 #else
   if (info_level > 1) {
-    fprintf(stdout,
+    fprintf(VERBSTREAM,
 	    "scalar sequence                                     ");
-    fflush(stdout);
+    fflush(VERBSTREAM);
   }
   generate_sequence_verif(matrix, *bdata, block_size, dimquot,
                           squvars, linvars, nvars, prime, st);
@@ -1395,16 +1396,16 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   if(info_level > 1){
     double rt_fglm = realtime()-st_fglm;
     double crt_fglm = cputime()-cst_fglm;
-    /* fprintf(stderr, "Time spent to generate sequence (elapsed): %.2f sec (%.2f Gops/sec)\n", rt_fglm, nops / rt_fglm); */
-    fprintf (stdout, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
+    /* fprintf(ERRSTREAM, "Time spent to generate sequence (elapsed): %.2f sec (%.2f Gops/sec)\n", rt_fglm, nops / rt_fglm); */
+    fprintf (VERBSTREAM, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
   }
 
   st_fglm = realtime();
   cst_fglm = cputime();
   if (info_level > 1) {
-    fprintf(stdout,
+    fprintf(VERBSTREAM,
 	    "elimination polynomial                              ");
-    fflush(stdout);
+    fflush(VERBSTREAM);
   }
 
   /* Berlekamp-Massey data */
@@ -1413,15 +1414,15 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   compute_minpoly(param, *bdata, *bdata_bms, dimquot);
 
   if(info_level > 1){
-    /* fprintf(stderr, "Time spent to compute eliminating polynomial (elapsed): %.2f sec\n", */
+    /* fprintf(ERRSTREAM, "Time spent to compute eliminating polynomial (elapsed): %.2f sec\n", */
     /*         realtime()-st_fglm); */
     double rt_fglm = realtime()-st_fglm;
     double crt_fglm = cputime()-cst_fglm;
-    fprintf (stdout, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
+    fprintf (VERBSTREAM, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
   }
   if (param->degelimpol < 1) {
       if (info_level > 1) {
-          fprintf (stdout, "Constant polynomial, computation will restart\n");
+          fprintf (VERBSTREAM, "Constant polynomial, computation will restart\n");
           goto restart;
       }
   }
@@ -1430,9 +1431,9 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
     st_fglm = realtime();
     cst_fglm = cputime();
     if (info_level > 1){
-      fprintf(stdout,
+      fprintf(VERBSTREAM,
 	      "parametrizations                                    ");
-      fflush(stdout);
+      fflush(VERBSTREAM);
     }
 
     if(compute_parametrizations(param, *bdata, *bdata_bms,
@@ -1440,15 +1441,15 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
                                 nlins, linvars, lineqs,
                                 nvars) == 0){
 
-      fprintf(stderr, "Matrix is not invertible (there should be a bug)\n");
+      fprintf(ERRSTREAM, "Matrix is not invertible (there should be a bug)\n");
       return NULL;
 
     }
     if (info_level > 1){
       double rt_fglm = realtime()-st_fglm;
       double crt_fglm = cputime()-cst_fglm;
-      fprintf(stdout, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
-      fprintf(stdout,
+      fprintf(VERBSTREAM, "%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
+      fprintf(VERBSTREAM,
 	      "-------------------------------------------------\
 -----------------------------------------------------\n");
     }
@@ -1456,12 +1457,12 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   else {
     /* computes the param of the radical */
     /* if(info_level){ */
-    /*   fprintf(stderr, "Elimination polynomial is not squarefree.\n"); */
+    /*   fprintf(ERRSTREAM, "Elimination polynomial is not squarefree.\n"); */
     /* } */
 
     st_fglm = realtime();
     if (info_level > 1){
-      fprintf (stdout,
+      fprintf (VERBSTREAM,
 	       "parametrizations                                               ");
     }
     int right_param= compute_parametrizations_non_shape_position_case(param,
@@ -1477,29 +1478,29 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
 
     if (info_level > 1){
       double rt_fglm = realtime()-st_fglm;
-      fprintf(stdout, "%.2f\n",rt_fglm);
-      fprintf(stdout,
+      fprintf(VERBSTREAM, "%.2f\n",rt_fglm);
+      fprintf(VERBSTREAM,
 	      "-------------------------------------------------\
 -----------------------------------------------------\n");
     }
     if (right_param == 0) {
       if(info_level){
-        fprintf(stderr, "Matrix is not invertible (there should be a bug)\n");
+        fprintf(ERRSTREAM, "Matrix is not invertible (there should be a bug)\n");
       }
       *success = 0;
       return NULL;
     }
     if (right_param == 1) {
         if(info_level){
-            fprintf(stdout,
+            fprintf(VERBSTREAM,
                     "Ideal not in generic position, parametrizations are not correct\n");
         }
         *success = 0;
     } else {
         if (right_param < (int)nvars) {
             if(info_level){
-                fprintf(stdout, "Only the first %d parametrizations of ",right_param-1);
-                fprintf(stdout, "the radical ideal are correct\n");
+                fprintf(VERBSTREAM, "Only the first %d parametrizations of ",right_param-1);
+                fprintf(VERBSTREAM, "the radical ideal are correct\n");
             }
             *success = 0;
         }
@@ -1508,7 +1509,7 @@ param_t *nmod_fglm_compute_trace_data(sp_matfglm_t *matrix, mod_t prime,
   }
   st->fglm_rtime = realtime() - st->fglm_rtime;
   st->fglm_ctime = cputime() - st->fglm_ctime;
-  print_fglm_data (stdout, st, matrix, param);
+  print_fglm_data (VERBSTREAM, st, matrix, param);
   return param;
 }
 
@@ -1535,7 +1536,7 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
                                        const int info_level,
 				       md_t *st){
 #if DEBUGFGLM > 0
-  fprintf(stderr, "prime = %u\n", prime);
+  fprintf(ERRSTREAM, "prime = %u\n", prime);
 #endif
 
 #if DEBUGFGLM >= 1
@@ -1545,8 +1546,8 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
 #endif
 
   if(prime>=1518500213){
-    fprintf(stderr, "Prime %u is too large.\n", prime);
-    fprintf(stderr, "One needs to use update linear algebra fglm functions\n");
+    fprintf(ERRSTREAM, "Prime %u is too large.\n", prime);
+    fprintf(ERRSTREAM, "One needs to use update linear algebra fglm functions\n");
     exit(1);
   }
 
@@ -1561,19 +1562,19 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
   const long nb = initialize_fglm_data(matrix, data_fglm, prime, sz, block_size);
 
   if(info_level){
-    fprintf(stdout, "[%u, %u], Dense / Total = %.2f%%\n",
+    fprintf(VERBSTREAM, "[%u, %u], Dense / Total = %.2f%%\n",
             matrix->ncols, matrix->nrows,
             100*((double)matrix->nrows / (double)matrix->ncols));
-    fprintf(stdout, "Density of non-trivial part %.2f%%\n",
+    fprintf(VERBSTREAM, "Density of non-trivial part %.2f%%\n",
             100-100*(float)nb/(float)sz);
   }
 
   const ulong dimquot = (matrix->ncols);
 
 #if DEBUGFGLM > 0
-  print_vec(stderr, data_fglm->vecinit, matrix->ncols);
-  print_vec(stderr, data_fglm->res, 2 * block_size * matrix->ncols);
-  fprintf(stderr, "\n");
+  print_vec(ERRSTREAM, data_fglm->vecinit, matrix->ncols);
+  print_vec(ERRSTREAM, data_fglm->res, 2 * block_size * matrix->ncols);
+  fprintf(ERRSTREAM, "\n");
 #endif
 
   double st_fglm = realtime();
@@ -1588,7 +1589,7 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
   if(info_level){
     double nops = 2 * (matrix->nrows/ 1000.0) * (matrix->ncols / 1000.0)  * (matrix->ncols / 1000.0);
     double rt_fglm = realtime()-st_fglm;
-    fprintf(stdout, "Time spent to generate sequence (elapsed): %.2f sec (%.2f Gops/sec)\n", rt_fglm, nops / rt_fglm);
+    fprintf(VERBSTREAM, "Time spent to generate sequence (elapsed): %.2f sec (%.2f Gops/sec)\n", rt_fglm, nops / rt_fglm);
   }
 
   st_fglm = realtime();
@@ -1598,12 +1599,12 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
   compute_minpoly(param, data_fglm, data_bms, dimquot);
 
   if(info_level){
-    fprintf(stdout, "Time spent to compute eliminating polynomial (elapsed): %.2f sec\n",
+    fprintf(VERBSTREAM, "Time spent to compute eliminating polynomial (elapsed): %.2f sec\n",
             realtime()-st_fglm);
   }
   if(param->elim->length-1 != deg_init){
     if(info_level){
-      fprintf(stdout, "Warning: Degree of elim poly = %ld\n", param->elim->length-1);
+      fprintf(VERBSTREAM, "Warning: Degree of elim poly = %ld\n", param->elim->length-1);
     }
     return 1;
   }
@@ -1615,7 +1616,7 @@ int nmod_fglm_compute_apply_trace_data(sp_matfglm_t *matrix,
 				nlins, linvars, lineqs,
 				nvars) == 0){
 
-      fprintf(stderr, "Matrix is not invertible (there should be a bug)\n");
+      fprintf(ERRSTREAM, "Matrix is not invertible (there should be a bug)\n");
       exit(1);
     }
 
@@ -1691,7 +1692,7 @@ guess_sequence_colon(sp_matfglmcol_t *matrix, fglm_data_t * data,
 				   prime, st);
     /* printf ("sparse_mat\n"); */
 #if DEBUGFGLM > 1
-    print_vec(stderr, data->vvec, matrix->ncols);
+    print_vec(ERRSTREAM, data->vvec, matrix->ncols);
 #endif
 
     CF_t *tmp = data->vecinit;
@@ -1716,12 +1717,12 @@ guess_sequence_colon(sp_matfglmcol_t *matrix, fglm_data_t * data,
     data_backup[i] = acc;
 
 #if DEBUGFGLM > 1
-    print_vec(stdout, data->res, 2*block_size * matrix->ncols);
+    print_vec(VERBSTREAM, data->res, 2*block_size * matrix->ncols);
 #endif
 
 #if DEBUGFGLM > 2
-    fprintf(stderr, "res = ");
-    print_vec(stdout, data->res+i*matrix->ncols, matrix->ncols);
+    fprintf(ERRSTREAM, "res = ");
+    print_vec(VERBSTREAM, data->res+i*matrix->ncols, matrix->ncols);
 #endif
     if (i == 2*tentative_degree-1) {
       /* printf ("guessing min poly\n"); */
@@ -1754,7 +1755,7 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
 			       const int info_level,
 			       md_t *st){
 #if DEBUGFGLM > 0
-  fprintf(stderr, "prime = %u\n", prime);
+  fprintf(ERRSTREAM, "prime = %u\n", prime);
 #endif
 
 #if DEBUGFGLM >= 1
@@ -1764,8 +1765,8 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
 #endif
   /* 1147878294 */
   if(prime>=1518500213){
-    fprintf(stderr, "Prime %u is too large.\n", prime);
-    fprintf(stderr, "One needs to use update linear algebra fglm functions\n");
+    fprintf(ERRSTREAM, "Prime %u is too large.\n", prime);
+    fprintf(ERRSTREAM, "One needs to use update linear algebra fglm functions\n");
     return NULL;
   }
 
@@ -1783,19 +1784,19 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
   long nb = initialize_fglm_colon_data(matrix, data, prime, sz, block_size);
 
   if(info_level){
-    fprintf(stdout, "[%u, %u], Dense / Total = %.2f%%\n",
+    fprintf(VERBSTREAM, "[%u, %u], Dense / Total = %.2f%%\n",
             matrix->ncols, matrix->nrows,
             100*((double)matrix->nrows / (double)matrix->ncols));
-    fprintf(stdout, "Density of non-trivial part %.2f%%\n",
+    fprintf(VERBSTREAM, "Density of non-trivial part %.2f%%\n",
             100-100*(float)nb/(float)sz);
   }
   ulong dimquot = (matrix->ncols);
   //Berlekamp-Massey data
   fglm_bms_data_t *data_bms = allocate_fglm_bms_data(dimquot, prime);
 #if DEBUGFGLM > 1
-  print_vec(stderr, data->vecinit, matrix->ncols);
-  print_vec(stderr, data->res, 2 * block_size * matrix->ncols);
-  fprintf(stderr, "\n");
+  print_vec(ERRSTREAM, data->vecinit, matrix->ncols);
+  print_vec(ERRSTREAM, data->res, 2 * block_size * matrix->ncols);
+  fprintf(ERRSTREAM, "\n");
 #endif
   long dim=0;
   double st0 = omp_get_wtime();
@@ -1811,13 +1812,13 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
   //////////////////////////////////////////////////////////////////
 
   if(info_level){
-    fprintf(stdout,"Time spent to generate sequence\n");
-    fprintf(stdout,"and compute eliminating polynomial (elapsed): %.2f sec\n",
+    fprintf(VERBSTREAM,"Time spent to generate sequence\n");
+    fprintf(VERBSTREAM,"and compute eliminating polynomial (elapsed): %.2f sec\n",
             omp_get_wtime()-st0);
-    fprintf(stdout, "Elimination done.\n");
+    fprintf(VERBSTREAM, "Elimination done.\n");
   }
 
-  /* nmod_poly_fprint_pretty(stderr, param->elim, "x"); fprintf (stdout,"\n"); */
+  /* nmod_poly_fprint_pretty(ERRSTREAM, param->elim, "x"); fprintf (VERBSTREAM,"\n"); */
 
   //////////////////////////////////////////////////////////////////
 
@@ -1831,30 +1832,30 @@ param_t *nmod_fglm_guess_colon(sp_matfglmcol_t *matrix,
 						  nvars, prime,
 						  1);
   if (right_param == 0) {
-    fprintf(stderr, "Matrix is not invertible (there should be a bug)\n");
+    fprintf(ERRSTREAM, "Matrix is not invertible (there should be a bug)\n");
     free_fglm_bms_data(data_bms);
     free_fglm_data(data);
     return NULL;
   } else {
     if (right_param == 1) {
       if(info_level){
-	fprintf(stdout,
+	fprintf(VERBSTREAM,
 		"Colon ideal not in generic position, parametrizations are not correct\n");
       }
     }
     else {
       if (right_param < nvars) {
 	if (info_level){
-	  fprintf(stdout, "Only the first %d parametrizations of ",right_param-1);
-	  fprintf(stdout, "the colon ideal are correct\n");
+	  fprintf(VERBSTREAM, "Only the first %d parametrizations of ",right_param-1);
+	  fprintf(VERBSTREAM, "the colon ideal are correct\n");
 	}
       }
     }
   }
   if(info_level){
-    fprintf(stdout, "Time spent to compute parametrizations (elapsed): %.2f sec\n",
+    fprintf(VERBSTREAM, "Time spent to compute parametrizations (elapsed): %.2f sec\n",
             omp_get_wtime()-st0);
-    fprintf(stdout, "Parametrizations done.\n");
+    fprintf(VERBSTREAM, "Parametrizations done.\n");
   }
   free_fglm_bms_data(data_bms);
   free_fglm_data(data);

--- a/src/msolve/Makefile.am
+++ b/src/msolve/Makefile.am
@@ -17,6 +17,7 @@ EXTRA_DIST	=	  msolve-data.h \
 								iofiles.c \
 								msolve.c \
 								primes.c \
+								streams.h \
 								../crt/longlong.h \
 								../crt/ulong_extras.h \
 								../crt/mpq_reconstruct.c \

--- a/src/msolve/duplicate.c
+++ b/src/msolve/duplicate.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "streams.h"
+
 static inline void duplicate_linear_data(int nthreads, int nvars, int nlins,
                                          nvars_t **blinvars, uint32_t **blineqs,
                                          nvars_t **bsquvars){
@@ -142,7 +144,7 @@ static inline void duplicate_data_mthread_trace(int nthreads,
                                                 nvars_t **blinvars,
                                                 uint32_t **blineqs,
                                                 nvars_t **bsquvars){
-  const long len0 = bmatrix[0]->nrows;  
+  const long len0 = bmatrix[0]->nrows;
   const long lextra_nf = bmatrix[0]->nnfs;
   const long len_xn = len0 - lextra_nf;
   const long dquot = bmatrix[0]->ncols;
@@ -202,7 +204,7 @@ static inline void duplicate_data_mthread_trace(int nthreads,
 
     sp_matfglm_t *matrix = bmatrix[i];
     if(posix_memalign((void **)&matrix->dense_mat, 32, sizeof(CF_t)*len1)){
-      fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
       exit(1);
     }
     else{
@@ -211,7 +213,7 @@ static inline void duplicate_data_mthread_trace(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-      fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
       exit(1);
     }
     else{
@@ -220,7 +222,7 @@ static inline void duplicate_data_mthread_trace(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-      fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
       exit(1);
     }
     else{
@@ -229,7 +231,7 @@ static inline void duplicate_data_mthread_trace(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len0)){
-      fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
       exit(1);
     }
     else{
@@ -238,7 +240,7 @@ static inline void duplicate_data_mthread_trace(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len0)){
-      fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
       exit(1);
     }
     else{
@@ -321,7 +323,7 @@ static inline void duplicate_data_mthread(int nthreads,
 
     sp_matfglm_t *matrix = bmatrix[i];
     if(posix_memalign((void **)&matrix->dense_mat, 32, sizeof(CF_t)*len1)){
-      fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
       exit(1);
     }
     else{
@@ -330,7 +332,7 @@ static inline void duplicate_data_mthread(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*(dquot - len_xn))){
-      fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
       exit(1);
     }
     else{
@@ -339,7 +341,7 @@ static inline void duplicate_data_mthread(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-      fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
       exit(1);
     }
     else{
@@ -348,7 +350,7 @@ static inline void duplicate_data_mthread(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len_xn)){
-      fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
       exit(1);
     }
     else{
@@ -357,7 +359,7 @@ static inline void duplicate_data_mthread(int nthreads,
       }
     }
     if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len_xn)){
-      fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+      fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
       exit(1);
     }
     else{
@@ -379,7 +381,7 @@ static inline void duplicate_data_mthread(int nthreads,
   }
 
   if(nthreads > 1){
-    fprintf(stderr, "Duplication of data to be implemented\n");
+    fprintf(ERRSTREAM, "Duplication of data to be implemented\n");
     exit(1);
   }
 

--- a/src/msolve/hilbert.c
+++ b/src/msolve/hilbert.c
@@ -21,6 +21,7 @@
 #include "../fglm/data_fglm.c"
 #include "../fglm/libfglm.h"
 #include "../neogb/meta_data.h"
+#include "streams.h"
 #define REDUCTION_ALLINONE 1
 
 void print_fglm_header(
@@ -244,7 +245,7 @@ static inline int32_t *monomial_basis(long length, long nvars,
   int32_t *ind = calloc(nvars, sizeof(int32_t));
 
 #ifdef DEBUGHILBERT
-  fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+  fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
   int32_t *new_basis = malloc(sizeof(int32_t) * nvars * (sum(ind, nvars) + nvars));
@@ -252,14 +253,14 @@ static inline int32_t *monomial_basis(long length, long nvars,
                                                basis, new_basis,
                                                length, bexp_lm);
 #ifdef DEBUGHILBERT
-  //  display_monomials_from_array(stderr, new_length, new_basis, gens);
-  fprintf(stderr, "%ld new elements.\n", new_length);
+  //  display_monomials_from_array(ERRSTREAM, new_length, new_basis, gens);
+  fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
   while(new_length>0){
     int32_t *basis2 = realloc(basis,
                               ((*dquot) + new_length) * nvars * sizeof(int32_t));
     if(basis2==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
 
@@ -274,16 +275,16 @@ static inline int32_t *monomial_basis(long length, long nvars,
     (*dquot) += new_length;
 
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "Update indices\n");
-    for(long i = 0; i < nvars; i++) fprintf(stderr, "%ld ", ind[i]);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+    fprintf(ERRSTREAM, "Update indices\n");
+    for(long i = 0; i < nvars; i++) fprintf(ERRSTREAM, "%ld ", ind[i]);
+    fprintf(ERRSTREAM, "\n");
+    fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
     int32_t *new_basis2 = realloc(new_basis,
                                  sizeof(int32_t) * nvars * (sum(ind, nvars) + nvars));
     if(new_basis2==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
     new_basis=new_basis2;
@@ -291,7 +292,7 @@ static inline int32_t *monomial_basis(long length, long nvars,
                                          basis, new_basis,
                                          length, bexp_lm);
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "%ld new elements.\n", new_length);
+    fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
   }
 
@@ -314,7 +315,7 @@ static inline int32_t *monomial_basis_colon(long length, long nvars,
   (*dquot) = 0;
 
   if(is_divisible_lexp(nvars, length, (basis), bexp_lm)){
-    fprintf(stderr, "Stop\n");
+    fprintf(ERRSTREAM, "Stop\n");
     free(basis);
     return NULL;
   }
@@ -324,7 +325,7 @@ static inline int32_t *monomial_basis_colon(long length, long nvars,
   int32_t *ind = calloc(nvars, sizeof(int32_t));
 
 #ifdef DEBUGHILBERT
-  fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+  fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
 
@@ -333,14 +334,14 @@ static inline int32_t *monomial_basis_colon(long length, long nvars,
                                             basis, new_basis,
                                             length, bexp_lm);
 #ifdef DEBUGHILBERT
-  display_monomials_from_array(stderr, new_length, new_basis, gens);
-  fprintf(stderr, "%ld new elements.\n", new_length);
+  display_monomials_from_array(ERRSTREAM, new_length, new_basis, gens);
+  fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
   long deg = 1;
   while(new_length>0 && deg <= maxdeg){
     int32_t *basis2 = realloc(basis, ((*dquot) + new_length) * nvars * sizeof(int32_t));
     if(basis2==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
 
@@ -355,16 +356,16 @@ static inline int32_t *monomial_basis_colon(long length, long nvars,
     (*dquot) += new_length;
 
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "Update indices\n");
-    for(long i = 0; i < nvars; i++) fprintf(stderr, "%ld ", ind[i]);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+    fprintf(ERRSTREAM, "Update indices\n");
+    for(long i = 0; i < nvars; i++) fprintf(ERRSTREAM, "%ld ", ind[i]);
+    fprintf(ERRSTREAM, "\n");
+    fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
     int32_t *new_basis2 = realloc(new_basis,
                                  sizeof(int32_t) * nvars * (sum(ind, nvars) + nvars));
     if(new_basis==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
     new_basis=new_basis2;
@@ -372,7 +373,7 @@ static inline int32_t *monomial_basis_colon(long length, long nvars,
                                          basis, new_basis,
                                          length, bexp_lm);
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "%ld new elements.\n", new_length);
+    fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
     deg++;
   }
@@ -395,7 +396,7 @@ static inline int32_t *monomial_basis_colon_no_zero(long length, long nvars,
   (*dquot) = 0;
 
   if(is_divisible_lexp(nvars, length, (basis), bexp_lm)){
-    fprintf(stderr, "Stop\n");
+    fprintf(ERRSTREAM, "Stop\n");
     free(basis);
     return NULL;
   }
@@ -405,7 +406,7 @@ static inline int32_t *monomial_basis_colon_no_zero(long length, long nvars,
   int32_t *ind = calloc(nvars, sizeof(int32_t));
 
 #ifdef DEBUGHILBERT
-  fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+  fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
   int32_t *new_basis = malloc(sizeof(int32_t) * nvars * (sum(ind, nvars) + nvars));
@@ -413,14 +414,14 @@ static inline int32_t *monomial_basis_colon_no_zero(long length, long nvars,
                                             basis, new_basis,
                                             length, bexp_lm);
 #ifdef DEBUGHILBERT
-  display_monomials_from_array(stderr, new_length, new_basis, gens);
-  fprintf(stderr, "%ld new elements.\n", new_length);
+  display_monomials_from_array(ERRSTREAM, new_length, new_basis, gens);
+  fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
   long deg = 1;
   while(new_length>0 && deg <= maxdeg){
     int32_t *basis2 = realloc(basis, ((*dquot) + new_length) * nvars * sizeof(int32_t));
     if(basis2==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
 
@@ -435,16 +436,16 @@ static inline int32_t *monomial_basis_colon_no_zero(long length, long nvars,
     (*dquot) += new_length;
 
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "Update indices\n");
-    for(long i = 0; i < nvars; i++) fprintf(stderr, "%ld ", ind[i]);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+    fprintf(ERRSTREAM, "Update indices\n");
+    for(long i = 0; i < nvars; i++) fprintf(ERRSTREAM, "%ld ", ind[i]);
+    fprintf(ERRSTREAM, "\n");
+    fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
     int32_t *new_basis2 = realloc(new_basis,
                                  sizeof(int32_t) * nvars * (sum(ind, nvars) + nvars));
     if(new_basis==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
     new_basis=new_basis2;
@@ -452,7 +453,7 @@ static inline int32_t *monomial_basis_colon_no_zero(long length, long nvars,
                                          basis, new_basis,
                                          length, bexp_lm);
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "%ld new elements.\n", new_length);
+    fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
     deg++;
   }
@@ -473,7 +474,7 @@ static inline int32_t *monomial_basis_colon_no_zero(long length, long nvars,
     }
   }
   if (new_dquot == 0) {
-    fprintf(stderr, "Vector space is too small\n");
+    fprintf(ERRSTREAM, "Vector space is too small\n");
     exit(1);
   }
   *dquot= new_dquot;
@@ -683,21 +684,21 @@ static inline void copy_poly_in_matrix_old(data_gens_ff_t *gens,
   }
   else{
     long i;
-    fprintf(stderr, "\n");
-    fprintf(stderr, "\n");
-    display_monomial_full(stderr, gens->nvars, NULL, 0, (*bexp) + (start+1)*gens->nvars);
-    fprintf(stderr, ", ");
-    display_monomial_full(stderr, gens->nvars, NULL, 0, lmb + ((end-start-2))*gens->nvars);
-    fprintf(stderr, ", ");
-    display_monomial_full(stderr, gens->nvars, NULL, 0, lmb + ((end-start-1))*gens->nvars);
-    fprintf(stderr, ", ");
-    display_monomial_full(stderr, gens->nvars, NULL, 0, lmb + ((end-start-3))*gens->nvars);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "\n");
+    fprintf(ERRSTREAM, "\n");
+    fprintf(ERRSTREAM, "\n");
+    display_monomial_full(ERRSTREAM, gens->nvars, NULL, 0, (*bexp) + (start+1)*gens->nvars);
+    fprintf(ERRSTREAM, ", ");
+    display_monomial_full(ERRSTREAM, gens->nvars, NULL, 0, lmb + ((end-start-2))*gens->nvars);
+    fprintf(ERRSTREAM, ", ");
+    display_monomial_full(ERRSTREAM, gens->nvars, NULL, 0, lmb + ((end-start-1))*gens->nvars);
+    fprintf(ERRSTREAM, ", ");
+    display_monomial_full(ERRSTREAM, gens->nvars, NULL, 0, lmb + ((end-start-3))*gens->nvars);
+    fprintf(ERRSTREAM, "\n");
+    fprintf(ERRSTREAM, "\n");
     for(i=(matrix->ncols)-1; i >= 0; i--){
-      display_monomial_full(stderr, gens->nvars, NULL, 0, (*bexp) + (start+1)*gens->nvars);fprintf(stderr, ", ");
-      display_monomial_full(stderr, gens->nvars, NULL, 0, lmb + (i*gens->nvars));
-      fprintf(stderr, "\n");
+      display_monomial_full(ERRSTREAM, gens->nvars, NULL, 0, (*bexp) + (start+1)*gens->nvars);fprintf(ERRSTREAM, ", ");
+      display_monomial_full(ERRSTREAM, gens->nvars, NULL, 0, lmb + (i*gens->nvars));
+      fprintf(ERRSTREAM, "\n");
       if(is_equal_exponent((*bexp) + (start+1)*gens->nvars,
                            lmb+(i*gens->nvars),
                            gens->nvars))
@@ -710,9 +711,9 @@ static inline void copy_poly_in_matrix_old(data_gens_ff_t *gens,
       }
     }
     else{
-      fprintf(stderr, "Some coefficients are null\n");
-      fprintf(stderr, "i + 1 = %ld\n", i + 1);
-      fprintf(stderr, "end - start - 1 = %ld\n", end - start - 1);
+      fprintf(ERRSTREAM, "Some coefficients are null\n");
+      fprintf(ERRSTREAM, "i + 1 = %ld\n", i + 1);
+      fprintf(ERRSTREAM, "end - start - 1 = %ld\n", end - start - 1);
       exit(1);
     }
   }
@@ -736,15 +737,15 @@ static inline void copy_poly_in_matrix(sp_matfglm_t* matrix,
   long end = start + pos;//(*blen)[pos];
 
 #if DEBUGBUILDMATRIX > 1
-  fprintf(stderr, "\nstart = %ld, end = %ld\n", start, end);
+  fprintf(ERRSTREAM, "\nstart = %ld, end = %ld\n", start, end);
   for(j = start; j < end; j++){
-    //    display_term(stderr, j, gens, blen, bcf, bexp);
+    //    display_term(ERRSTREAM, j, gens, blen, bcf, bexp);
     if(j < end - 1){
     //    if(j < (*blen)[pos] - 1){
-      fprintf(stderr, "+");
+      fprintf(ERRSTREAM, "+");
     }
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
 
   long N = nrows * (matrix->ncols) - (start + 1);
@@ -789,15 +790,15 @@ copy_poly_in_matrixcol(sp_matfglmcol_t* matrix, long nrows,
   long end = start + pos;//(*blen)[pos];
 
 #if DEBUGBUILDMATRIX > 0
-  fprintf(stderr, "\nstart = %ld, end = %ld\n", start, end);
+  fprintf(ERRSTREAM, "\nstart = %ld, end = %ld\n", start, end);
   for(j = start; j < end; j++){
-    //    display_term(stderr, j, gens, blen, bcf, bexp);
+    //    display_term(ERRSTREAM, j, gens, blen, bcf, bexp);
     if(j < end - 1){
     //    if(j < (*blen)[pos] - 1){
-      fprintf(stderr, "+");
+      fprintf(ERRSTREAM, "+");
     }
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   long N = nrows * (matrix->ncols) - (start + 1);
 
@@ -839,15 +840,15 @@ copy_poly_in_matrixcol_no_zero(sp_matfglmcol_t* matrix, long nrows,
 
 #if DEBUGBUILDMATRIX > 0
   int32_t j;
-  fprintf(stderr, "\nstart = %ld, end = %ld\n", start, end);
+  fprintf(ERRSTREAM, "\nstart = %ld, end = %ld\n", start, end);
   for(j = start; j < end; j++){
-    //    display_term(stderr, j, gens, blen, bcf, bexp);
+    //    display_term(ERRSTREAM, j, gens, blen, bcf, bexp);
     if(j < end - 1){
     //    if(j < (*blen)[pos] - 1){
-      fprintf(stderr, "+");
+      fprintf(ERRSTREAM, "+");
     }
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   long i;
   long N = nrows * matrix->ncols ;
@@ -1316,7 +1317,7 @@ static inline int32_t *monomial_basis_enlarged(long length, long nvars,
   int32_t *ind = calloc(nvars, sizeof(int32_t));
 
 #ifdef DEBUGHILBERT
-  fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+  fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
   uint64_t len_newbs = nvars * (sum(ind, nvars) + nvars);
 
@@ -1327,15 +1328,15 @@ static inline int32_t *monomial_basis_enlarged(long length, long nvars,
 
   deg++;
 #ifdef DEBUGHILBERT
-  //  display_monomials_from_array(stderr, new_length, new_basis, gens);
-  fprintf(stderr, "%ld new elements.\n", new_length);
+  //  display_monomials_from_array(ERRSTREAM, new_length, new_basis, gens);
+  fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
 
   while(new_length>0 && deg <= maxdeg){
     int32_t *basis2 = realloc(basis,
                               ((*dquot) + new_length) * (nvars) * sizeof(int32_t));
     if(basis2==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
 
@@ -1353,10 +1354,10 @@ static inline int32_t *monomial_basis_enlarged(long length, long nvars,
     (*dquot) += new_length;
 
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "Update indices\n");
-    for(long i = 0; i < nvars; i++) fprintf(stderr, "%ld ", ind[i]);
-    fprintf(stderr, "\n");
-    fprintf(stderr, "new = %ld \n", sum(ind, nvars) + nvars);
+    fprintf(ERRSTREAM, "Update indices\n");
+    for(long i = 0; i < nvars; i++) fprintf(ERRSTREAM, "%ld ", ind[i]);
+    fprintf(ERRSTREAM, "\n");
+    fprintf(ERRSTREAM, "new = %ld \n", sum(ind, nvars) + nvars);
 #endif
 
     len_newbs = nvars * (sum(ind, nvars) + nvars);
@@ -1364,7 +1365,7 @@ static inline int32_t *monomial_basis_enlarged(long length, long nvars,
     int32_t *new_basis2 = realloc(new_basis,
                                   sizeof(int32_t) * len_newbs);
     if(new_basis==NULL){
-      fprintf(stderr, "Issue with realloc\n");
+      fprintf(ERRSTREAM, "Issue with realloc\n");
       exit(1);
     }
     new_basis=new_basis2;
@@ -1375,7 +1376,7 @@ static inline int32_t *monomial_basis_enlarged(long length, long nvars,
     deg++;
 
 #ifdef DEBUGHILBERT
-    fprintf(stderr, "%ld new elements.\n", new_length);
+    fprintf(ERRSTREAM, "%ld new elements.\n", new_length);
 #endif
   }
 
@@ -1410,12 +1411,12 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
   long len_xn = get_div_xn(bexp_lm, bld, nv, div_xn);
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
 
   /* lengths of the polys which we need to build the matrix */
@@ -1436,11 +1437,11 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
   }
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "Length of polynomials whose leading terms are divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length of polynomials whose leading terms are divisible by x_n\n");
   for(long i = 0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   sp_matfglm_t *matrix ALIGNED32 = calloc(1, sizeof(sp_matfglm_t));
   matrix->charac = fc;
@@ -1450,7 +1451,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
   long len2 = dquot - len_xn;
 
   if(posix_memalign((void **)&(matrix->dense_mat), 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -1459,7 +1460,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -1468,7 +1469,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -1477,7 +1478,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
     }
   }
   if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -1486,7 +1487,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -1504,11 +1505,11 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
       /* mult by xn stays in the basis */
       matrix->triv_idx[l_triv] = i;
@@ -1519,7 +1520,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
     else{
       /* we get now outside the basis */
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       matrix->dense_idx[l_dens] = i;
       l_dens++;
@@ -1530,7 +1531,7 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
         nrows++;
         count++;
         if(len_xn < count && i < dquot){
-          fprintf(stderr, "One should not arrive here (build_matrix)\n");
+          fprintf(ERRSTREAM, "One should not arrive here (build_matrix)\n");
           free(matrix->dense_mat);
           free(matrix->dense_idx);
           free(matrix->triv_idx);
@@ -1544,10 +1545,10 @@ static inline sp_matfglm_t * build_matrixn(int32_t *lmb, long dquot, int32_t bld
         }
       }
       else{
-        fprintf(stderr, "\nStaircase is not generic\n");
-        fprintf(stderr, "Multiplication by ");
-        display_monomial_full(stderr, nv, NULL, 0, exp);
-        fprintf(stderr, " gets outside the staircase\n");
+        fprintf(ERRSTREAM, "\nStaircase is not generic\n");
+        fprintf(ERRSTREAM, "Multiplication by ");
+        display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+        fprintf(ERRSTREAM, " gets outside the staircase\n");
         free(matrix->dense_mat);
         free(matrix->dense_idx);
         free(matrix->triv_idx);
@@ -1635,21 +1636,21 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 				   &len_not_xn,maxdeg+1);
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the Gb) "
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the Gb) "
 	  "which are divisible by x_n "
 	  "and with bounded degree: %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the Gb) "
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the Gb) "
 	  "which are not divisible by x_n "
 	  "and with bounded degree: %ld\n", len_not_xn);
   for(long i=0; i < len_not_xn; i++){
-    fprintf(stderr, "%d, ", div_not_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_not_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   long count_lm = 0;
   /* list of monomials in the staircase that leave the staircase after
@@ -1666,20 +1667,20 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	int32_t *exp = lmb + (i * nv);
 	if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX>0
-	  display_monomial_full(stderr, nv, NULL, 0, exp);
-	  fprintf(stderr, " => remains in monomial basis\n");
+	  display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+	  fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 	}
 	else{
 	  /* we get now outside the basis */
 #if DEBUGBUILDMATRIX > 0
-	  display_monomial_full(stderr, nv, NULL, 0, exp);
-	  fprintf(stderr, " => does NOT remain in monomial basis");
+	  display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+	  fprintf(ERRSTREAM, " => does NOT remain in monomial basis");
 #endif
 	  if(is_equal_exponent_xxn(exp, bexp_lm+(div_xn[count_lm])*nv, nv)){
 	    count_lm++;
 #if DEBUGBUILDMATRIX > 0
-	    fprintf(stderr, " => lands on a leading monomial\n");
+	    fprintf(ERRSTREAM, " => lands on a leading monomial\n");
 #endif
 	  }
 	  else{
@@ -1689,7 +1690,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 		extra_nf[count_not_lm]=i;
 		count_not_lm++;
 #if DEBUGBUILDMATRIX > 0
-		fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+		fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 		is_divisible = 1;
 		break;
@@ -1697,7 +1698,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	    }
 	    if (!is_divisible) {
 #if DEBUGBUILDMATRIX > 0
-	      fprintf(stderr, " => lands on 0\n");
+	      fprintf(ERRSTREAM, " => lands on 0\n");
 #endif
 	      zeronf[count_zero]=i;
 	      count_zero++;
@@ -1761,16 +1762,16 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     tbr->lmps[k]  = k; /* fix input element in tbr */
   }
   /* printf ("polynomials to be reduced\n"); */
-  /* print_msolve_polynomials_ff(stdout, 0, tbr->lml, tbr, bht, */
+  /* print_msolve_polynomials_ff(VERBSTREAM, 0, tbr->lml, tbr, bht, */
   /* 			      st, gens->vnames, 0); */
   int32_t err = 0;
   tbr = core_nf(tbr, st, mul, bs, &err);
   if (err) {
-    fprintf(stderr,"Problem with normalform, stopped computation.\n");
+    fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
     exit(1);
   }
   /* printf ("reductions\n"); */
-  /* print_msolve_polynomials_ff(stdout, tobereduced, tbr->lml, tbr, bht, */
+  /* print_msolve_polynomials_ff(VERBSTREAM, tobereduced, tbr->lml, tbr, bht, */
   /* 			      st, gens->vnames, 0); */
 #endif
   printf ("Number of zero normal forms: %ld\n",count_zero);
@@ -1791,11 +1792,11 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
   }
 
 #if DEBUGBUILDMATRIX > 0
-  fprintf(stderr, "Length of polynomials whose leading terms are divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length of polynomials whose leading terms are divisible by x_n\n");
   for(long i = 0; i < len_xn-1; i++){
-    fprintf(stderr, "%u, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%u, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "%u\n", len_gb_xn[len_xn-1]);
+  fprintf(ERRSTREAM, "%u\n", len_gb_xn[len_xn-1]);
 #endif
   sp_matfglmcol_t *matrix ALIGNED32 = calloc(1, sizeof(sp_matfglmcol_t));
   matrix->charac = fc;
@@ -1806,7 +1807,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
   long len2 = dquot - (len_xn + count_not_lm + count_zero);
 
   if(posix_memalign((void **)&(matrix->dense_mat), 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -1815,7 +1816,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -1824,7 +1825,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -1833,7 +1834,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->zero_idx, 32, sizeof(CF_t)*count_zero)){
-    fprintf(stderr, "Problem when allocating matrix->zero_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->zero_idx\n");
     exit(1);
   }
   else{
@@ -1843,7 +1844,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
   }
   if(posix_memalign((void **)&matrix->dense_idx, 32,
 		    sizeof(CF_t)*(len_xn + count_not_lm))){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -1852,7 +1853,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*(len_xn + count_not_lm))){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -1870,11 +1871,11 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
   for(long i = 0; i < dquot; i++){
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
-    /* display_monomial_full(stderr, nv, NULL, 0, exp); */
+    /* display_monomial_full(ERRSTREAM, nv, NULL, 0, exp); */
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      display_monomial_full(stderr, nv, NULL, 0, exp);
-      fprintf(stderr, " => remains in monomial basis\n");
+      display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
       /* mult by xn stays in the basis */
       matrix->triv_idx[l_triv] = i;
@@ -1885,12 +1886,12 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     else{
       /* we get now outside the basis */
 #if DEBUGBUILDMATRIX > 0
-      display_monomial_full(stderr, nv, NULL, 0, exp);
-      fprintf(stderr, " => does NOT remain in monomial basis");
+      display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis");
 #endif
       if (i == zeronf[l_zero]){
 #if DEBUGBUILDMATRIX > 0
-	fprintf(stderr, " => lands on 0\n");
+	fprintf(ERRSTREAM, " => lands on 0\n");
 	printf ("zero row #%ld in row #%ld\n",l_zero,i);
 #endif
 	matrix->zero_idx[l_zero] = i;
@@ -1901,7 +1902,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	l_dens++;
 	if(is_equal_exponent_xxn(exp, bexp_lm+(div_xn[count])*nv, nv)){
 #if DEBUGBUILDMATRIX > 0
-	  fprintf(stderr, " => lands on a leading monomial\n");
+	  fprintf(ERRSTREAM, " => lands on a leading monomial\n");
 #endif
 	  copy_poly_in_matrixcol(matrix, nrows, bcf, bexp, blen,
 				 start_cf_gb_xn[count], len_gb_xn[count], lmb,
@@ -1909,7 +1910,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	  nrows++;
 	  count++;
 	  if(len_xn < count && i < dquot){
-	    fprintf(stderr, "One should not arrive here (build_matrix)\n");
+	    fprintf(ERRSTREAM, "One should not arrive here (build_matrix)\n");
 	    free(lens);
 	    free(exps);
 	    free(cfs);
@@ -1930,7 +1931,7 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	}
 	else if (i == extra_nf[count_nf]){
 #if DEBUGBUILDMATRIX > 0
-	  fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+	  fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 #if REDUCTION_ALLINONE
 	  copy_extrapoly_in_matrixcol(matrix, nrows, lmb,
@@ -1945,15 +1946,15 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
 	    tbr->lmps[k]  = k; /* fix input element in tbr */
 	  }
 	  /* printf ("mononomial to be reduced\n"); */
-	  /* print_msolve_polynomials_ff(stdout, 0, tbr->lml, tbr, bht, */
+	  /* print_msolve_polynomials_ff(VERBSTREAM, 0, tbr->lml, tbr, bht, */
 	  /* 		      st, gens->vnames, 0); */
 	  success = core_nf(&tbr, &bht, &st, mul, bs);
 	  if (!success) {
-	    fprintf(stderr,"Problem with normalform, stopped computation.\n");
+	    fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
 	    exit(1);
 	  }
 	  /* printf ("reduction\n"); */
-	  /* print_msolve_polynomials_ff(stdout, 1, tbr->lml, tbr, bht, */
+	  /* print_msolve_polynomials_ff(VERBSTREAM, 1, tbr->lml, tbr, bht, */
 	  /* 		      st, gens->vnames, 0); */
 	  copy_extrapoly_in_matrixcol(matrix, nrows, lmb,
 				      1,
@@ -1994,15 +1995,15 @@ build_matrixn_colon(int32_t *lmb, long dquot, int32_t bld,
     tbr->lmps[k]  = k; /* fix input element in tbr */
   }
   /* printf ("shifts of phi to be reduced\n"); */
-  /* print_msolve_polynomials_ff(stdout, 0, tbr->lml, tbr, bht, */
+  /* print_msolve_polynomials_ff(VERBSTREAM, 0, tbr->lml, tbr, bht, */
   /* 			      st, gens->vnames, 0); */
   int success = core_nf(&tbr, &bht, &st, mul, bs);
   if (!success) {
-    fprintf(stderr,"Problem with normalform, stopped computation.\n");
+    fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
     exit(1);
   }
   /* printf ("reductions\n"); */
-  /* print_msolve_polynomials_ff(stdout, 2*nv-2, tbr->lml, tbr, bht, */
+  /* print_msolve_polynomials_ff(VERBSTREAM, 2*nv-2, tbr->lml, tbr, bht, */
   /* 			      st, gens->vnames, 0); */
   for (long i = 0; i < 2*nv - 2; i++) {
     copy_extrapoly_in_vector(leftvectorsparam[i], dquot, lmb,
@@ -2085,21 +2086,21 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 				   &len_not_xn,maxdeg+1);
 
 #if DEBUGBUILDMATRIX > 0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the Gb) "
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the Gb) "
 	  "which are divisible by x_n "
 	  "and with bounded degree: %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the Gb) "
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the Gb) "
 	  "which are not divisible by x_n "
 	  "and with bounded degree: %ld\n", len_not_xn);
   for(long i=0; i < len_not_xn; i++){
-    fprintf(stderr, "%d, ", div_not_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_not_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   long count_lm = 0;
   /* list of monomials in the staircase that leave the staircase after
@@ -2116,20 +2117,20 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	int32_t *exp = lmb + (i * nv);
 	if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-	  display_monomial_full(stderr, nv, NULL, 0, exp);
-	  fprintf(stderr, " => remains in monomial basis\n");
+	  display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+	  fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 	}
 	else{
 	  /* we get now outside the basis */
 #if DEBUGBUILDMATRIX > 0
-	  display_monomial_full(stderr, nv, NULL, 0, exp);
-	  fprintf(stderr, " => does NOT remain in monomial basis");
+	  display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+	  fprintf(ERRSTREAM, " => does NOT remain in monomial basis");
 #endif
 	  if(is_equal_exponent_xxn(exp, bexp_lm+(div_xn[count_lm])*nv, nv)){
 	    count_lm++;
 #if DEBUGBUILDMATRIX > 0
-	    fprintf(stderr, " => lands on a leading monomial\n");
+	    fprintf(ERRSTREAM, " => lands on a leading monomial\n");
 #endif
 	  }
 	  else{
@@ -2138,7 +2139,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 		extra_nf[count_not_lm]=i;
 		count_not_lm++;
 #if DEBUGBUILDMATRIX > 0
-		fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+		fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 		/* is_divisible = 1; */
 		break;
@@ -2146,7 +2147,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	    }
 /* 	    if (!is_divisible) { */
 /* #if DEBUGBUILDMATRIX > 0 */
-/* 	      fprintf(stderr, " => land on 0\n"); */
+/* 	      fprintf(ERRSTREAM, " => land on 0\n"); */
 /* #endif */
 /* 	      zeronf[count_zero]=i; */
 /* 	      count_zero++; */
@@ -2208,16 +2209,16 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
     tbr->lmps[k]  = k; /* fix input element in tbr */
   }
   /* printf ("polynomials to be reduced\n"); */
-  /* print_msolve_polynomials_ff(stdout, 0, tbr->lml, tbr, bht, */
+  /* print_msolve_polynomials_ff(VERBSTREAM, 0, tbr->lml, tbr, bht, */
   /* 			      st, gens->vnames, 0); */
   int32_t err = 0;
   tbr = core_nf(tbr, st, mul, bs, &err);
   if (err) {
-    fprintf(stderr,"Problem with normalform, stopped computation.\n");
+    fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
     exit(1);
   }
   /* printf ("reductions\n"); */
-  /* print_msolve_polynomials_ff(stdout, tobereduced, tbr->lml, tbr, bht, */
+  /* print_msolve_polynomials_ff(VERBSTREAM, tobereduced, tbr->lml, tbr, bht, */
   /* 			      st, gens->vnames, 0); */
   /* printf ("Number of zero normal forms: %ld\n",count_zero); */
   /* lengths of the polys which we need to build the matrix */
@@ -2237,11 +2238,11 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
   }
 
 #if DEBUGBUILDMATRIX > 0
-  fprintf(stderr, "Length of polynomials whose leading terms are divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length of polynomials whose leading terms are divisible by x_n\n");
   for(long i = 0; i < len_xn-1; i++){
-    fprintf(stderr, "%u, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%u, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "%u\n", len_gb_xn[len_xn-1]);
+  fprintf(ERRSTREAM, "%u\n", len_gb_xn[len_xn-1]);
 #endif
   sp_matfglmcol_t *matrix ALIGNED32 = calloc(1, sizeof(sp_matfglmcol_t));
   matrix->charac = fc;
@@ -2252,7 +2253,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
   long len2 = dquot - (len_xn + count_not_lm /* + count_zero*/);
 
   if(posix_memalign((void **)&(matrix->dense_mat), 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -2261,7 +2262,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -2270,7 +2271,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -2279,7 +2280,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   /* if(posix_memalign((void **)&matrix->zero_idx, 32, sizeof(CF_t)*count_zero)){ */
-  /*   fprintf(stderr, "Problem when allocating matrix->zero_idx\n"); */
+  /*   fprintf(ERRSTREAM, "Problem when allocating matrix->zero_idx\n"); */
   /*   exit(1); */
   /* } */
   /* else{ */
@@ -2289,7 +2290,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
   /* } */
   if(posix_memalign((void **)&matrix->dense_idx, 32,
 		    sizeof(CF_t)*(len_xn + count_not_lm))){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -2298,7 +2299,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*(len_xn + count_not_lm))){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -2328,11 +2329,11 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
   for(long i = 0; i < dquot; i++){
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
-    /* display_monomial_full(stderr, nv, NULL, 0, exp); */
+    /* display_monomial_full(ERRSTREAM, nv, NULL, 0, exp); */
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      display_monomial_full(stderr, nv, NULL, 0, exp);
-      fprintf(stderr, " => remains in monomial basis\n");
+      display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
       /* mult by xn stays in the basis */
       matrix->triv_idx[l_triv] = i;
@@ -2343,12 +2344,12 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
     else{
       /* we get now outside the basis */
 #if DEBUGBUILDMATRIX > 0
-      display_monomial_full(stderr, nv, NULL, 0, exp);
-      fprintf(stderr, " => does NOT remain in monomial basis");
+      display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis");
 #endif
 /*       if (i == zeronf[l_zero]){ */
 /* #if DEBUGBUILDMATRIX > 0 */
-/* 	fprintf(stderr, " => land on 0\n"); */
+/* 	fprintf(ERRSTREAM, " => land on 0\n"); */
 /* 	printf ("zero row #%ld in row #%ld\n",l_zero,i); */
 /* #endif */
 /* 	matrix->zero_idx[l_zero] = i; */
@@ -2359,7 +2360,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	l_dens++;
 	if(is_equal_exponent_xxn(exp, bexp_lm+(div_xn[count])*nv, nv)){
 #if DEBUGBUILDMATRIX > 0
-	  fprintf(stderr, " => lands on a leading monomial\n");
+	  fprintf(ERRSTREAM, " => lands on a leading monomial\n");
 #endif
 	  copy_poly_in_matrixcol_no_zero(matrix, nrows, bcf, bexp, blen,
 					 start_cf_gb_xn[count],
@@ -2367,7 +2368,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	  nrows++;
 	  count++;
 	  if(len_xn < count && i < dquot){
-	    fprintf(stderr, "One should not arrive here (build_matrix)\n");
+	    fprintf(ERRSTREAM, "One should not arrive here (build_matrix)\n");
 	    free(lens);
 	    free(exps);
 	    free(cfs);
@@ -2388,7 +2389,7 @@ build_matrixn_colon_no_zero(int32_t *lmb, long dquot, int32_t bld,
 	}
 	else if (i == extra_nf[count_nf]){
 #if DEBUGBUILDMATRIX > 0
-	  fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+	  fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 	  copy_extrapoly_in_matrixcol_no_zero(matrix, nrows, lmb,
 					      tobereduced + count_nf,
@@ -2464,12 +2465,12 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
   long len_xn = get_div_xn(bexp_lm, bld, nv, div_xn);
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
 
 
@@ -2493,11 +2494,11 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
   }
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "Length ofpolynomials whose leading terms is divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length ofpolynomials whose leading terms is divisible by x_n\n");
   for(long i = 0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   sp_matfglm_t *matrix ALIGNED32 = calloc(1, sizeof(sp_matfglm_t));
   matrix->charac = fc;
@@ -2507,7 +2508,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
   long len2 = dquot - len_xn;
 
   if(posix_memalign((void **)&matrix->dense_mat, 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -2516,7 +2517,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -2525,7 +2526,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -2534,7 +2535,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -2543,7 +2544,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -2561,12 +2562,12 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
-    //    fprintf(stderr, "\n");
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+    //    fprintf(ERRSTREAM, "\n");
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 
       matrix->triv_idx[l_triv] = i;
@@ -2577,7 +2578,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
     else{
 
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       matrix->dense_idx[l_dens] = i;
       l_dens++;
@@ -2588,7 +2589,7 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
         nrows++;
         count++;
         if(len_xn < count && i < dquot){
-          fprintf(stderr, "One should not arrive here (build_matrix)\n");
+          fprintf(ERRSTREAM, "One should not arrive here (build_matrix)\n");
           free(matrix->dense_mat);
           free(matrix->dense_idx);
           free(matrix->triv_idx);
@@ -2603,10 +2604,10 @@ static inline sp_matfglm_t * build_matrixn_trace(int32_t **bdiv_xn,
         }
       }
       else{
-        fprintf(stderr, "Staircase is not generic\n");
-        fprintf(stderr, "Multiplication by ");
-        display_monomial_full(stderr, nv, NULL, 0, exp);
-        fprintf(stderr, " gets outside the staircase\n");
+        fprintf(ERRSTREAM, "Staircase is not generic\n");
+        fprintf(ERRSTREAM, "Multiplication by ");
+        display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+        fprintf(ERRSTREAM, " gets outside the staircase\n");
         free(matrix->dense_mat);
         free(matrix->dense_idx);
         free(matrix->triv_idx);
@@ -2663,12 +2664,12 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
   long len_xn = get_div_xn(bexp_lm, bs->lml, nv, div_xn);
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
 
   int32_t *len_gb_xn = malloc(sizeof(int32_t) * len_xn);
@@ -2689,11 +2690,11 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
   }
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "Length ofpolynomials whose leading terms is divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length ofpolynomials whose leading terms is divisible by x_n\n");
   for(long i = 0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   sp_matfglm_t *matrix ALIGNED32 = calloc(1, sizeof(sp_matfglm_t));
   matrix->charac = fc;
@@ -2703,7 +2704,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
   long len2 = dquot - len_xn;
 
   if(posix_memalign((void **)&matrix->dense_mat, 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -2712,7 +2713,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -2721,7 +2722,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -2730,7 +2731,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
     }
   }
   if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -2739,7 +2740,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -2757,12 +2758,12 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
-    //    fprintf(stderr, "\n");
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+    //    fprintf(ERRSTREAM, "\n");
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 
       matrix->triv_idx[l_triv] = i;
@@ -2773,7 +2774,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
     else{
 
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       matrix->dense_idx[l_dens] = i;
       l_dens++;
@@ -2785,7 +2786,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
         nrows++;
         count++;
         if(len_xn < count && i < dquot){
-          fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
+          fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
           free(matrix->dense_mat);
           free(matrix->dense_idx);
           free(matrix->triv_idx);
@@ -2800,10 +2801,10 @@ static inline sp_matfglm_t * build_matrixn_from_bs(int32_t *lmb, long dquot,
         }
       }
       else{
-	fprintf(stdout, "Staircase is not generic\n");
-	fprintf(stdout, "Multiplication by ");
-	display_monomial_full(stdout, nv, NULL, 0, exp);
-	fprintf(stdout, " gets outside the staircase\n");
+	fprintf(VERBSTREAM, "Staircase is not generic\n");
+	fprintf(VERBSTREAM, "Multiplication by ");
+	display_monomial_full(VERBSTREAM, nv, NULL, 0, exp);
+	fprintf(VERBSTREAM, " gets outside the staircase\n");
         free(matrix->dense_mat);
         free(matrix->dense_idx);
         free(matrix->triv_idx);
@@ -2868,13 +2869,13 @@ static inline void compute_modular_matrix(sp_matfglm_t *matrix,
     matrix->dst[i] = trace_det->dst[i];
   }
 #ifdef DEBUGLIFTMAT
-  fprintf(stderr, "\nModular matrix (prime = %u)\n", prime);
+  fprintf(ERRSTREAM, "\nModular matrix (prime = %u)\n", prime);
   for(int i = 0; i < matrix->nrows; i++){
     int nc = i*matrix->ncols;
     for(int j = 0; j < matrix->ncols; j++){
-      fprintf(stderr, "%u, ", matrix->dense_mat[nc+j]);
+      fprintf(ERRSTREAM, "%u, ", matrix->dense_mat[nc+j]);
     }
-    fprintf(stderr, "\n");
+    fprintf(ERRSTREAM, "\n");
   }
 #endif
 }
@@ -2951,11 +2952,11 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 
       matrix->triv_idx[l_triv] = i;
@@ -2966,7 +2967,7 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
     else{
 
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       matrix->dense_idx[l_dens] = i;
       l_dens++;
@@ -2978,7 +2979,7 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
         nrows++;
         count++;
         if(len_xn < count && i < dquot){
-          fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
+          fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
           free(matrix->dense_mat);
           free(matrix->dense_idx);
           free(matrix->triv_idx);
@@ -2993,10 +2994,10 @@ static inline void build_matrixn_from_bs_trace_application(sp_matfglm_t *matrix,
         }
       }
       else{
-        fprintf(stderr, "Staircase is not generic\n");
-        fprintf(stderr, "Multiplication by ");
-        display_monomial_full(stderr, nv, NULL, 0, exp);
-        fprintf(stderr, " gets outside the staircase\n");
+        fprintf(ERRSTREAM, "Staircase is not generic\n");
+        fprintf(ERRSTREAM, "Multiplication by ");
+        display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+        fprintf(ERRSTREAM, " gets outside the staircase\n");
         free(matrix->dense_mat);
         free(matrix->dense_idx);
         free(matrix->triv_idx);
@@ -3072,7 +3073,7 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
     int32_t err = 0;
     tbr = core_nf(tbr, md, mul, bs, &err);
     if (err) {
-      fprintf(stderr,"Problem with normalform, stopped computation.\n");
+      fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
       exit(1);
     }
     free(mul);
@@ -3125,11 +3126,11 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 
       matrix->triv_idx[l_triv] = i;
@@ -3140,7 +3141,7 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
     else{
 
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       matrix->dense_idx[l_dens] = i;
       l_dens++;
@@ -3152,7 +3153,7 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
         nrows++;
         count++;
         if(len_xn < count && i < dquot){
-          fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
+          fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
           free(matrix->dense_mat);
           free(matrix->dense_idx);
           free(matrix->triv_idx);
@@ -3174,14 +3175,14 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
       }
       else if (i == extra_nf[count_nf]){
 #if DEBUGBUILDMATRIX > 0
-	fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+	fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 	copy_nf_in_matrix_from_bs(matrix, nrows, count_nf, lmb,
 				  tbr, ht, evi, st, nv);
 	nrows++;
 	count_nf++;
 	if (count_not_lm < count_nf && i < dquot) {
-          fprintf(stderr, "One should not arrive here (build_matrix with trace)\n");
+          fprintf(ERRSTREAM, "One should not arrive here (build_matrix with trace)\n");
           free(matrix->dense_mat);
           free(matrix->dense_idx);
           free(matrix->triv_idx);
@@ -3202,10 +3203,10 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
         }
       }
       else{ /* should not arrive here */
-        fprintf(stderr, "Staircase is not generic\n");
-        fprintf(stderr, "Multiplication by ");
-        display_monomial_full(stderr, nv, NULL, 0, exp);
-        fprintf(stderr, " gets outside the staircase\n");
+        fprintf(ERRSTREAM, "Staircase is not generic\n");
+        fprintf(ERRSTREAM, "Multiplication by ");
+        display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+        fprintf(ERRSTREAM, " gets outside the staircase\n");
         free(matrix->dense_mat);
         free(matrix->dense_idx);
         free(matrix->triv_idx);
@@ -3243,7 +3244,7 @@ static inline void build_matrixn_unstable_from_bs_trace_application(sp_matfglm_t
   }
   free(evi);
   /* if(st->info_level){ */
-  /*   fprintf(stderr, "[%lu, %lu], Free / Dense = %.2f%%\n", */
+  /*   fprintf(ERRSTREAM, "[%lu, %lu], Free / Dense = %.2f%%\n", */
   /*           len0, len_xn, */
   /*           100*((double)len_xn / (double)len0)); */
   /* } */
@@ -3269,12 +3270,12 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
 
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the staircase) which are divisible by x_n = %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
 
   *blen_gb_xn = malloc(sizeof(int32_t) * len_xn);
@@ -3298,11 +3299,11 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
   }
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "Length of polynomials whose leading terms is divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length of polynomials whose leading terms is divisible by x_n\n");
   for(long i = 0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   sp_matfglm_t *matrix ALIGNED32 = calloc(1, sizeof(sp_matfglm_t));
   matrix->charac = fc;
@@ -3312,7 +3313,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
   long len2 = dquot - len_xn;
 
   if(posix_memalign((void **)&matrix->dense_mat, 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -3321,7 +3322,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -3330,7 +3331,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -3339,7 +3340,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -3348,7 +3349,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len_xn)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -3366,12 +3367,12 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
-    //    fprintf(stderr, "\n");
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+    //    fprintf(ERRSTREAM, "\n");
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 
       matrix->triv_idx[l_triv] = i;
@@ -3381,7 +3382,7 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
     }
     else{
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       int boo = 0;
       if(count < len_xn){
@@ -3399,17 +3400,17 @@ static inline sp_matfglm_t * build_matrixn_from_bs_trace(int32_t **bdiv_xn,
 
         if(len_xn < count && i < dquot){
           if(info_level){
-            fprintf(stdout, "Staircase is not generic (1 => explain better)\n");
+            fprintf(VERBSTREAM, "Staircase is not generic (1 => explain better)\n");
           }
           return NULL;
         }
       }
       else{
         if(info_level){
-          fprintf(stdout, "Staircase is not generic\n");
-          fprintf(stdout, "Multiplication by ");
-          display_monomial_full(stdout, nv, NULL, 0, exp);
-          fprintf(stdout, " gets outside the staircase\n");
+          fprintf(VERBSTREAM, "Staircase is not generic\n");
+          fprintf(VERBSTREAM, "Multiplication by ");
+          display_monomial_full(VERBSTREAM, nv, NULL, 0, exp);
+          fprintf(VERBSTREAM, " gets outside the staircase\n");
         }
         return NULL;
       }
@@ -3454,12 +3455,12 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   long len_xn = get_div_xn(bexp_lm, bs->lml, nv, div_xn);
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "\n");
-  fprintf(stderr, "Number of monomials (in the Gröbner basis) which are divisible by x_n = %ld\n", len_xn);
+  fprintf(ERRSTREAM, "\n");
+  fprintf(ERRSTREAM, "Number of monomials (in the Gröbner basis) which are divisible by x_n = %ld\n", len_xn);
   for(long i=0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", div_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", div_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
   *blen_gb_xn = malloc(sizeof(int32_t) * len_xn);
   int32_t *len_gb_xn = *blen_gb_xn;
@@ -3482,11 +3483,11 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   }
 
 #if DEBUGBUILDMATRIX>0
-  fprintf(stderr, "Length of polynomials whose leading terms is divisible by x_n\n");
+  fprintf(ERRSTREAM, "Length of polynomials whose leading terms is divisible by x_n\n");
   for(long i = 0; i < len_xn; i++){
-    fprintf(stderr, "%d, ", len_gb_xn[i]);
+    fprintf(ERRSTREAM, "%d, ", len_gb_xn[i]);
   }
-  fprintf(stderr, "\n");
+  fprintf(ERRSTREAM, "\n");
 #endif
 
   long count_lm = 0;
@@ -3504,20 +3505,20 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     int32_t *exp = lmb + (i * nv);
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX>0
-      display_monomial_full(stderr, nv, NULL, 0, exp);
-      fprintf(stderr, " => remains in monomial basis\n");
+      display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
     }
     else{
       /* we get now outside the basis */
 #if DEBUGBUILDMATRIX > 0
-      display_monomial_full(stderr, nv, NULL, 0, exp);
-      fprintf(stderr, " => does NOT remain in monomial basis");
+      display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis");
 #endif
       if(is_equal_exponent_xxn(exp, bexp_lm+(div_xn[count_lm])*nv, nv)){
 	count_lm++;
 #if DEBUGBUILDMATRIX > 0
-	fprintf(stderr, " => lands on a leading monomial\n");
+	fprintf(ERRSTREAM, " => lands on a leading monomial\n");
 #endif
       }
       else{
@@ -3527,7 +3528,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 	    extra_nf[count_not_lm]=i;
 	    count_not_lm++;
 #if DEBUGBUILDMATRIX > 0
-	    fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+	    fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 	    is_divisible = 1;
 	    break;
@@ -3535,7 +3536,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 	}
 	if (!is_divisible) {
 #if DEBUGBUILDMATRIX > 0
-	  fprintf(stderr, " => BUG\n");
+	  fprintf(ERRSTREAM, " => BUG\n");
 #endif
 	}
       }
@@ -3568,8 +3569,8 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 
   if (count_not_lm > threshold) {
     if(info_level){
-      fprintf(stdout, "Staircase is not generic\n");
-      fprintf(stdout, "and too many normal forms need to be computed\n");
+      fprintf(VERBSTREAM, "Staircase is not generic\n");
+      fprintf(VERBSTREAM, "and too many normal forms need to be computed\n");
     }
     return NULL;
   }
@@ -3620,11 +3621,11 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     }
     int32_t err = 0;
     if (st->info_level > 1) {
-      fprintf (stdout, "normal forms\n");
+      fprintf (VERBSTREAM, "normal forms\n");
     }
     tbr = core_nf(tbr, md, mul, bs, &err);
     if (err) {
-      fprintf(stderr, "Problem with normalform, stopped computation.\n");
+      fprintf(ERRSTREAM, "Problem with normalform, stopped computation.\n");
       exit(1);
     }
     free(mul);
@@ -3639,7 +3640,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   long len2 = dquot - len0;
 
   if(posix_memalign((void **)&matrix->dense_mat, 32, sizeof(CF_t)*len1)){
-    fprintf(stderr, "Problem when allocating matrix->dense_mat\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_mat\n");
     exit(1);
   }
   else{
@@ -3648,7 +3649,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     }
   }
   if(posix_memalign((void **)&matrix->triv_idx, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_idx\n");
     exit(1);
   }
   else{
@@ -3657,7 +3658,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     }
   }
   if(posix_memalign((void **)&matrix->triv_pos, 32, sizeof(CF_t)*len2)){
-    fprintf(stderr, "Problem when allocating matrix->triv_pos\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->triv_pos\n");
     exit(1);
   }
   else{
@@ -3666,7 +3667,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     }
   }
   if(posix_memalign((void **)&matrix->dense_idx, 32, sizeof(CF_t)*len0)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -3675,7 +3676,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     }
   }
   if(posix_memalign((void **)&matrix->dst, 32, sizeof(CF_t)*len0)){
-    fprintf(stderr, "Problem when allocating matrix->dense_idx\n");
+    fprintf(ERRSTREAM, "Problem when allocating matrix->dense_idx\n");
     exit(1);
   }
   else{
@@ -3697,12 +3698,12 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     long pos = -1;
     int32_t *exp = lmb + (i * nv);
 #if DEBUGBUILDMATRIX > 0
-    display_monomial_full(stderr, nv, NULL, 0, exp);
-    //    fprintf(stderr, "\n");
+    display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+    //    fprintf(ERRSTREAM, "\n");
 #endif
     if(member_xxn(exp, lmb + (i * nv), dquot - i, &pos, nv)){
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => remains in monomial basis\n");
+      fprintf(ERRSTREAM, " => remains in monomial basis\n");
 #endif
 
       matrix->triv_idx[l_triv] = i;
@@ -3712,13 +3713,13 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
     }
     else{
 #if DEBUGBUILDMATRIX > 0
-      fprintf(stderr, " => does NOT remain in monomial basis\n");
+      fprintf(ERRSTREAM, " => does NOT remain in monomial basis\n");
 #endif
       matrix->dense_idx[l_dens] = i;
       l_dens++;
       if(is_equal_exponent_xxn(exp, bexp_lm+(div_xn[count])*nv, nv)){
 #if DEBUGBUILDMATRIX > 0
-	fprintf(stderr, " => lands on a leading monomial\n");
+	fprintf(ERRSTREAM, " => lands on a leading monomial\n");
 #endif
         copy_poly_in_matrix_from_bs(matrix, nrows, bs, ht, //bcf, bexp, blen,
                                     div_xn[count], len_gb_xn[count],
@@ -3733,7 +3734,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
         count++;
         if(len_xn < count && i < dquot){
 	  if (info_level){
-	    fprintf(stdout, "Staircase is not generic (1 => explain better)\n");
+	    fprintf(VERBSTREAM, "Staircase is not generic (1 => explain better)\n");
 	  }
 	  free(evi);
           return NULL;
@@ -3741,7 +3742,7 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
       }
       else if (i == extra_nf[count_nf]){
 #if DEBUGBUILDMATRIX > 0
-	fprintf(stderr, " => lands on a MULTIPLE of a leading monomial\n");
+	fprintf(ERRSTREAM, " => lands on a MULTIPLE of a leading monomial\n");
 #endif
 	copy_nf_in_matrix_from_bs(matrix, nrows, count_nf, lmb,
 				  tbr, ht, evi, st, nv);
@@ -3754,17 +3755,17 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
 	count_nf++;
         if(count_not_lm < count_nf && i < dquot){
 	  if (info_level){
-	    fprintf(stdout, "Staircase is not generic (1 => explain better)\n");
+	    fprintf(VERBSTREAM, "Staircase is not generic (1 => explain better)\n");
 	  }
 	  free(evi);
           return NULL;
         }
       }
       else{ /* should not arrive here */
-	fprintf(stderr, "Staircase is not generic\n");
-	fprintf(stderr, "Multiplication by ");
-	display_monomial_full(stderr, nv, NULL, 0, exp);
-	fprintf(stderr, " gets outside the staircase\n");
+	fprintf(ERRSTREAM, "Staircase is not generic\n");
+	fprintf(ERRSTREAM, "Multiplication by ");
+	display_monomial_full(ERRSTREAM, nv, NULL, 0, exp);
+	fprintf(ERRSTREAM, " gets outside the staircase\n");
 	free(evi);
         return NULL;
       }
@@ -3790,9 +3791,9 @@ static inline sp_matfglm_t * build_matrixn_unstable_from_bs_trace(int32_t **bdiv
   if (st->info_level > 1){
     double rt_fglm = realtime()-st_fglm;
     double crt_fglm = cputime()-cst_fglm;
-    fprintf (stdout,
+    fprintf (VERBSTREAM,
 	     "multiplication matrix                               ");
-    fprintf (stdout,"%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
+    fprintf (VERBSTREAM,"%15.2f | %-13.2f\n",rt_fglm,crt_fglm);
   }
   free(evi);
   return matrix;

--- a/src/msolve/iofiles.c
+++ b/src/msolve/iofiles.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "streams.h"
+
 static inline void store_exponent(const char *term, data_gens_ff_t *gens, int32_t pos)
 {
     len_t i, j, k;
@@ -345,7 +347,7 @@ static void print_ff_nf_data(
             fclose(ofile);
         }
         else{
-            print_msolve_polynomials_ff(stdout, from, to, bs, ht,
+            print_msolve_polynomials_ff(OUTSTREAM, from, to, bs, ht,
                     st, gens->vnames, 2-print_gb, 1);
         }
     }
@@ -368,7 +370,7 @@ static void print_ff_basis_data(
             fclose(ofile);
         }
         else{
-            print_msolve_polynomials_ff(stdout, 0, bs->lml, bs, ht,
+            print_msolve_polynomials_ff(OUTSTREAM, 0, bs->lml, bs, ht,
                     st, gens->vnames, 2-print_gb, 0);
         }
     }
@@ -534,7 +536,7 @@ static void get_variables(FILE *fh, char * line, int max_line_size,
   if (fgets(line, max_line_size, fh) != NULL) {
     tmp = line;
   } else {
-    fprintf(stderr,"Bad file format (variable names).\n");
+    fprintf(ERRSTREAM,"Bad file format (variable names).\n");
     /* free(vnames);
      * free(line); */
     fclose(fh);
@@ -556,7 +558,7 @@ static void get_characteristic(FILE *fh, char * line, int max_line_size,
     if(tmp_mod >= 0){
       *field_char = (int32_t) tmp_mod;
       if(tmp_mod > 2147483647){
-        fprintf(stderr, "Warning: characteristic must be 0 or < 2^31\n");
+        fprintf(ERRSTREAM, "Warning: characteristic must be 0 or < 2^31\n");
         free(vnames);
         free(line);
         fclose(fh);
@@ -564,7 +566,7 @@ static void get_characteristic(FILE *fh, char * line, int max_line_size,
       }
     }
     else{
-      fprintf(stderr, "Bad file format (characteristic)\n");
+      fprintf(ERRSTREAM, "Bad file format (characteristic)\n");
       free(vnames);
       free(line);
       fclose(fh);
@@ -677,7 +679,7 @@ static inline void get_term(const char *line, char **prev_pos,
       * if minus is nearer */
     if (term_diff_add > term_diff_minus) {
       if( term_diff_minus >= *term_size){
-        fprintf(stderr, "Too large input integers, exit...\n");
+        fprintf(ERRSTREAM, "Too large input integers, exit...\n");
         exit(1);
       }
       memcpy(*term, start_pos, term_diff_minus);
@@ -687,7 +689,7 @@ static inline void get_term(const char *line, char **prev_pos,
     /** if plus is nearer */
     } else {
       if(term_diff_add >= *term_size){
-        fprintf(stderr, "Too large input integers, exit...\n");
+        fprintf(ERRSTREAM, "Too large input integers, exit...\n");
         exit(1);
       }
       memcpy(*term, start_pos, term_diff_add);
@@ -699,7 +701,7 @@ static inline void get_term(const char *line, char **prev_pos,
     if (curr_pos_add != NULL) {
       size_t term_diff_add   = (size_t)(curr_pos_add - start_pos);
       if(term_diff_add >= *term_size){
-        fprintf(stderr, "Too large input integers, exit...\n");
+        fprintf(ERRSTREAM, "Too large input integers, exit...\n");
         exit(1);
       }
       memcpy(*term, start_pos, term_diff_add);
@@ -710,7 +712,7 @@ static inline void get_term(const char *line, char **prev_pos,
     if (curr_pos_minus != NULL) {
       size_t term_diff_minus = (size_t)(curr_pos_minus - start_pos);
       if(term_diff_minus >= *term_size){
-        fprintf(stderr, "Too large input integers, exit...\n");
+        fprintf(ERRSTREAM, "Too large input integers, exit...\n");
         exit(1);
       }
       memcpy(*term, start_pos, term_diff_minus);
@@ -722,7 +724,7 @@ static inline void get_term(const char *line, char **prev_pos,
       size_t prev_idx  = (size_t)(start_pos - line);
       size_t term_diff = strlen(line) + 1 - prev_idx;
       if(term_diff >= *term_size){
-        fprintf(stderr, "Too large input integers, exit...\n");
+        fprintf(ERRSTREAM, "Too large input integers, exit...\n");
         exit(1);
       }
       memcpy(*term, start_pos, term_diff);
@@ -804,7 +806,7 @@ static int get_coefficient_ff_and_term_from_line(char *line, int32_t nterms,
 }
 
 static void beginning_strterm_to_mpz(char *str, mpz_t *num, mpz_t *den){
-  /* fprintf(stderr, "TERM = %s\n", str); */
+  /* fprintf(ERRSTREAM, "TERM = %s\n", str); */
   mpq_t tmp;
   mpq_init(tmp);
   mpz_set_ui(*num, 1);
@@ -923,7 +925,7 @@ static void get_coeffs_and_exponents_ff32(FILE *fh, nelts_t all_nterms,
         }
         if(get_coefficient_ff_and_term_from_line(line, gens->lens[i], gens->field_char,
                     gens, pos)){
-            fprintf(stderr, "Error when reading file (exit but things need to be free-ed)\n");
+            fprintf(ERRSTREAM, "Error when reading file (exit but things need to be free-ed)\n");
             free(line);
             fclose(fh);
             exit(1);
@@ -970,7 +972,7 @@ static void get_coeffs_and_exponents_mpz(FILE *fh, nelts_t all_nterms,
         }
         if(get_coefficient_mpz_and_term_from_line(line, gens->lens[i], gens->field_char,
                     gens, pos)){
-            fprintf(stderr, "Error when reading file (exit but things need to be free-ed)\n");
+            fprintf(ERRSTREAM, "Error when reading file (exit but things need to be free-ed)\n");
             free(line);
             fclose(fh);
             exit(1);
@@ -998,7 +1000,7 @@ static int duplicate_vnames(char **vnames, int32_t nvars) {
   for (i = 1; i < nvars; ++i) {
     for (j = 0; j < i; ++j) {
       if (strcmp(vnames[i], vnames[j]) == 0) {
-        fprintf(stderr, "Duplicate variable name %s in input file.\n", vnames[i]);
+        fprintf(ERRSTREAM, "Duplicate variable name %s in input file.\n", vnames[i]);
         return 1;
       }
     }
@@ -1013,11 +1015,11 @@ static inline void get_data_from_file(char *fn, int32_t *nr_vars,
                                       int32_t *nr_gens, data_gens_ff_t *gens){
   *nr_vars = get_nvars(fn);
   if (*nr_vars == -1)
-    fprintf(stderr,"Bad file format (first line).\n");
+    fprintf(ERRSTREAM,"Bad file format (first line).\n");
 
   *nr_gens = get_ngenerators(fn);
   if (*nr_gens == -1)
-    fprintf(stderr,"Bad file format (generators).\n");
+    fprintf(ERRSTREAM,"Bad file format (generators).\n");
 
   const int max_line_size  = 1073741824;
   char *line  = (char *)malloc((nelts_t)max_line_size * sizeof(char));
@@ -1147,7 +1149,7 @@ static inline void display_gens(FILE *fh, data_gens_ff_t *gens){
 
 static inline void get_poly_bin(FILE *file, mpz_upoly_t pol){
   if(!fscanf(file, "%d\n", &pol->alloc)){
-    fprintf(stderr, "Issue when reading binary file (alloc = %d)\n", pol->alloc);
+    fprintf(ERRSTREAM, "Issue when reading binary file (alloc = %d)\n", pol->alloc);
     exit(1);
   }
 
@@ -1157,7 +1159,7 @@ static inline void get_poly_bin(FILE *file, mpz_upoly_t pol){
   for(int32_t i = 0; i < pol->length; i++){
     mpz_init(pol->coeffs[i]);
     if(!mpz_inp_raw(pol->coeffs[i], file)){
-      fprintf(stderr, "An error occurred when reading file (i=%d)\n", i);
+      fprintf(ERRSTREAM, "An error occurred when reading file (i=%d)\n", i);
       exit(1);
     }
   }
@@ -1165,7 +1167,7 @@ static inline void get_poly_bin(FILE *file, mpz_upoly_t pol){
 
 static inline void get_poly(FILE *file, mpz_upoly_t pol){
   if(!fscanf(file, "%d\n", &pol->alloc)){
-    fprintf(stderr, "Issue when reading binary file (alloc = %d)\n", pol->alloc);
+    fprintf(ERRSTREAM, "Issue when reading binary file (alloc = %d)\n", pol->alloc);
     exit(1);
   }
 
@@ -1174,7 +1176,7 @@ static inline void get_poly(FILE *file, mpz_upoly_t pol){
   for(int32_t i = 0; i < pol->length; i++){
     mpz_init(pol->coeffs[i]);
     if(!mpz_inp_str(pol->coeffs[i], file, 10)){
-      fprintf(stderr, "An error occurred when reading file (i=%d)\n", i);
+      fprintf(ERRSTREAM, "An error occurred when reading file (i=%d)\n", i);
       exit(1);
     }
   }
@@ -1187,7 +1189,7 @@ static inline void get_single_param_from_file_bin(FILE *file, mpz_param_t param)
   get_poly_bin(file, param->denom);
 
   if(!fscanf(file, "%d\n", &param->nvars)){
-    fprintf(stderr, "Issue when reading binary file (nvars)\n");
+    fprintf(ERRSTREAM, "Issue when reading binary file (nvars)\n");
     exit(1);
   }
 
@@ -1202,7 +1204,7 @@ static inline void get_single_param_from_file_bin(FILE *file, mpz_param_t param)
 
     mpz_init(param->cfs[i]);
     if(!mpz_inp_raw(param->cfs[i], file)){
-      fprintf(stderr, "An error occurred when reading file (lcm coord i=%d)\n", i);
+      fprintf(ERRSTREAM, "An error occurred when reading file (lcm coord i=%d)\n", i);
       exit(1);
     }
 
@@ -1215,7 +1217,7 @@ static inline void get_single_param_from_file(FILE *file, mpz_param_t param){
 
   get_poly(file, param->denom);
   if(!fscanf(file, "%d\n", &param->nvars)){
-    fprintf(stderr, "Issue when reading binary file (nvars)\n");
+    fprintf(ERRSTREAM, "Issue when reading binary file (nvars)\n");
     exit(1);
   }
 
@@ -1231,7 +1233,7 @@ static inline void get_single_param_from_file(FILE *file, mpz_param_t param){
     mpz_init(param->cfs[i]);
 
     if(!mpz_inp_str(param->cfs[i], file, 10)){
-      fprintf(stderr, "An error occurred when reading file (i=%d)\n", i);
+      fprintf(ERRSTREAM, "An error occurred when reading file (i=%d)\n", i);
       exit(1);
     }
 
@@ -1243,7 +1245,7 @@ static inline void get_params_from_file_bin(char *fn, mpz_param_array_t lparam){
   FILE *file = fopen(fn,"r");
   int32_t nb = 0;
   if(!fscanf(file, "%d\n", &nb)){
-    fprintf(stderr, "Issue when reading binary file (nb = %d)\n", nb);
+    fprintf(ERRSTREAM, "Issue when reading binary file (nb = %d)\n", nb);
     exit(1);
   }
   lparam->nb = nb;
@@ -1259,7 +1261,7 @@ static inline void get_params_from_file(char *fn, mpz_param_array_t lparam){
   FILE *file = fopen(fn,"r");
   int32_t nb = 0;
   if(!fscanf(file, "%d\n", &nb)){
-    fprintf(stderr, "Issue when reading binary file (nb = %d)\n", nb);
+    fprintf(ERRSTREAM, "Issue when reading binary file (nb = %d)\n", nb);
     exit(1);
   }
   lparam->nb = nb;

--- a/src/msolve/libmsolve.c
+++ b/src/msolve/libmsolve.c
@@ -24,6 +24,7 @@
 
 #include "msolve-data.h"
 #include "msolve-data.c"
+#include "streams.h"
 #include "iofiles.c"
 #include "hilbert.c"
 #include "primes.c"

--- a/src/msolve/lifting-gb.c
+++ b/src/msolve/lifting-gb.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include<flint/fmpz.h>
+#include "streams.h"
 
 #define NBCHECK 2
 #ifndef MIN
@@ -230,7 +231,7 @@ static inline void gb_modpoly_realloc(gb_modpoly_t modgbs,
                                             modgbs->alloc * sizeof(mp_limb_t));
 
   if(newprimes == NULL){
-    fprintf(stderr, "Problem when reallocating modgbs (primes)\n");
+    fprintf(ERRSTREAM, "Problem when reallocating modgbs (primes)\n");
     exit(1);
   }
   modgbs->primes = newprimes;
@@ -241,7 +242,7 @@ static inline void gb_modpoly_realloc(gb_modpoly_t modgbs,
   mp_limb_t *ncf_64 = (mp_limb_t *)realloc(modgbs->cf_64,
                                          modgbs->alloc * sizeof(mp_limb_t));
   if(ncf_64 == NULL){
-    fprintf(stderr, "Problem when reallocating modgbs (cfs)\n");
+    fprintf(ERRSTREAM, "Problem when reallocating modgbs (cfs)\n");
     exit(1);
   }
   modgbs->cf_64 = ncf_64;
@@ -253,7 +254,7 @@ static inline void gb_modpoly_realloc(gb_modpoly_t modgbs,
       uint32_t *newcfs_pol = (uint32_t *)realloc(modgbs->modpolys[i]->cf_32[j],
                                                  modgbs->alloc * sizeof(uint32_t));
       if(newcfs_pol == NULL){
-        fprintf(stderr, "Problem when reallocating modgbs (cfs_pol)\n");
+        fprintf(ERRSTREAM, "Problem when reallocating modgbs (cfs_pol)\n");
       }
       modgbs->modpolys[i]->cf_32[j] = newcfs_pol;
       for(uint32_t k = oldalloc; k < modgbs->alloc; k++){
@@ -605,7 +606,7 @@ static inline int modpgbs_set(gb_modpoly_t modgbs,
                               const int32_t fc,
                               int32_t start, const long elim){
   if(modgbs->nprimes >= modgbs->alloc-1){
-    fprintf(stderr, "Not enough space in modgbs\n");
+    fprintf(ERRSTREAM, "Not enough space in modgbs\n");
     exit(1);
   }
   modgbs->primes[modgbs->nprimes] = fc;
@@ -623,7 +624,7 @@ static inline int modpgbs_set(gb_modpoly_t modgbs,
   for(i = start; i < modgbs->ld; i++){
     idx = bs->lmps[i];
     if (bs->hm[idx] == NULL) {
-      fprintf(stderr, " poly is 0\n");
+      fprintf(ERRSTREAM, " poly is 0\n");
       exit(1);
     } else {
       /* hm  = bs->hm[idx]+OFFSET; */
@@ -714,7 +715,7 @@ static int32_t gb_modular_trace_learning(gb_modpoly_t modgbs,
     st->f4_qq_round = 1;
     bs = core_gba(bs_qq, st, &err, fc);
     if (err) {
-      fprintf(stderr,"Problem with F4, stopped computation.\n");
+      fprintf(ERRSTREAM,"Problem with F4, stopped computation.\n");
       exit(1);
     }
 
@@ -724,11 +725,11 @@ static int32_t gb_modular_trace_learning(gb_modpoly_t modgbs,
     ht_t *bht = bs->ht;
 
     if(info_level > 2){
-        fprintf(stdout, "------------------------------------------\n");
-        fprintf(stdout, "#ADDITIONS       %13lu\n", (unsigned long)st->trace_nr_add * 1000);
-        fprintf(stdout, "#MULTIPLICATIONS %13lu\n", (unsigned long)st->trace_nr_mult * 1000);
-        fprintf(stdout, "#REDUCTIONS      %13lu\n", (unsigned long)st->trace_nr_red);
-        fprintf(stdout, "------------------------------------------\n");
+        fprintf(VERBSTREAM, "------------------------------------------\n");
+        fprintf(VERBSTREAM, "#ADDITIONS       %13lu\n", (unsigned long)st->trace_nr_add * 1000);
+        fprintf(VERBSTREAM, "#MULTIPLICATIONS %13lu\n", (unsigned long)st->trace_nr_mult * 1000);
+        fprintf(VERBSTREAM, "#REDUCTIONS      %13lu\n", (unsigned long)st->trace_nr_red);
+        fprintf(VERBSTREAM, "------------------------------------------\n");
     }
 
     /* Leading monomials from Grobner basis */
@@ -774,7 +775,7 @@ static int32_t gb_modular_trace_learning(gb_modpoly_t modgbs,
     int is_empty = 0;
     if(bs->lml == 1){
         if(info_level){
-            fprintf(stdout, "Grobner basis has a single element\n");
+            fprintf(VERBSTREAM, "Grobner basis has a single element\n");
         }
         is_empty = 1;
         for(int i = 0; i < bht->nv; i++){
@@ -1311,7 +1312,7 @@ restart:
     primeinit = fc;
   }
   if(info_level){
-      fprintf(stdout, "Initial prime = %d\n", msd->lp->p[0]);
+      fprintf(VERBSTREAM, "Initial prime = %d\n", msd->lp->p[0]);
   }
 
   int success = 1;
@@ -1365,7 +1366,7 @@ restart:
     gb_modpoly_realloc((*modgbsp), 1, dlift->S);
 
 #ifdef DEBUGGBLIFT
-    display_gbmodpoly_cf_32(stderr, (*modgbsp));
+    display_gbmodpoly_cf_32(ERRSTREAM, (*modgbsp));
 #endif
 
     if(!dlinit){
@@ -1379,18 +1380,18 @@ restart:
     }
 
     if(info_level){
-      fprintf(stdout,"\n---------- COMPUTATIONAL DATA -----------\n");
+      fprintf(VERBSTREAM,"\n---------- COMPUTATIONAL DATA -----------\n");
       int s= 0;
       for(int i = 0; i < dlift->nsteps; i++){
-        fprintf(stdout, "[%d]", dlift->steps[i]);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "[%d]", dlift->steps[i]);
+        fflush(VERBSTREAM);
         s+=dlift->steps[i];
       }
-      fprintf(stdout, "\n");
-      fprintf(stdout,
+      fprintf(VERBSTREAM, "\n");
+      fprintf(VERBSTREAM,
 	      "#polynomials to lift %14lu\n",
 	      (unsigned long) s);
-      fprintf(stdout, "-----------------------------------------\n");
+      fprintf(VERBSTREAM, "-----------------------------------------\n");
     }
 
     if(is_empty || success == 0 || fc) {
@@ -1405,7 +1406,7 @@ restart:
       free_rrec_data(recdata1);
       free_rrec_data(recdata2);
 
-      fprintf(stdout, "Something went wrong in the learning phase, msolve restarts.");
+      fprintf(VERBSTREAM, "Something went wrong in the learning phase, msolve restarts.");
       /* return core_groebner_qq(modgbsp, bs, msd, st, errp, fc, print_gb); */
       goto restart;
     }
@@ -1418,7 +1419,7 @@ restart:
     learn = 0;
     prime = next_prime(rand() % (1303905301 - (1<<30) + 1) + (1<<30));
     if(info_level){
-        fprintf(stdout, "New prime = %d\n", prime);
+        fprintf(VERBSTREAM, "New prime = %d\n", prime);
     }
     while(apply){
 
@@ -1470,38 +1471,38 @@ restart:
       nprimes += 1; /* at the moment, multi-mod comp is mono-threaded */
       if(nprimes == 1){
         if(info_level>2){
-          fprintf(stdout, "------------------------------------------\n");
-          fprintf(stdout, "#ADDITIONS       %13lu\n", (unsigned long)st->application_nr_add * 1000);
-          fprintf(stdout, "#MULTIPLICATIONS %13lu\n", (unsigned long)st->application_nr_mult * 1000);
-          fprintf(stdout, "#REDUCTIONS      %13lu\n", (unsigned long)st->application_nr_red);
-          fprintf(stdout, "------------------------------------------\n");
+          fprintf(VERBSTREAM, "------------------------------------------\n");
+          fprintf(VERBSTREAM, "#ADDITIONS       %13lu\n", (unsigned long)st->application_nr_add * 1000);
+          fprintf(VERBSTREAM, "#MULTIPLICATIONS %13lu\n", (unsigned long)st->application_nr_mult * 1000);
+          fprintf(VERBSTREAM, "#REDUCTIONS      %13lu\n", (unsigned long)st->application_nr_red);
+          fprintf(VERBSTREAM, "------------------------------------------\n");
         }
         /* if(info_level>1){ */
-        /*   fprintf(stderr, "Application phase %.2f Gops/sec\n", */
+        /*   fprintf(ERRSTREAM, "Application phase %.2f Gops/sec\n", */
         /*           (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4)); */
-        /*   fprintf(stderr, "Elapsed time: %.2f\n", stf4); */
+        /*   fprintf(ERRSTREAM, "Elapsed time: %.2f\n", stf4); */
         /* } */
 	  if(info_level){
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "\n---------------- TIMINGS ----------------\n");
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "multi-mod overall(elapsed) %9.2f sec\n",
 		    stf4);
 	    if (info_level > 1){
-	      fprintf(stdout,
+	      fprintf(VERBSTREAM,
 		      "learning phase             %9.2f Gops/sec\n",
 		      (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(st->learning_rtime));
-	      fprintf(stdout,
+	      fprintf(VERBSTREAM,
 		      "application phase          %9.2f Gops/sec\n",
 		      (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
 	    }
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "-----------------------------------------\n");
         }
       if (info_level) {
-	      fprintf(stdout,
+	      fprintf(VERBSTREAM,
 		      "\nmulti-modular steps\n");
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 -----------------------------------------------------\n");
         }
       }
@@ -1510,7 +1511,7 @@ restart:
         if(msd->bad_primes[i] == 1){
             bad = 1;
             if(info_level > 1){
-                fprintf(stdout, "[!]");
+                fprintf(VERBSTREAM, "[!]");
             }
             nbadprimes++;
             msd->bad_primes[i] = 0;
@@ -1518,7 +1519,7 @@ restart:
         if(msd->bad_primes[i] == 2){
             bad = 1;
             if(info_level > 1){
-                fprintf(stdout, "[!!]");
+                fprintf(VERBSTREAM, "[!!]");
             }
             /* nbadprimes = nprimes; */
             nbadprimes++;
@@ -1528,8 +1529,8 @@ restart:
 
       if(nbadprimes >= nprimes){
         if(info_level){
-          fprintf(stdout, "\nToo many bad primes, computation will restart\n");
-          fprintf(stdout, "-------------------------------------------------\
+          fprintf(VERBSTREAM, "\nToo many bad primes, computation will restart\n");
+          fprintf(VERBSTREAM, "-------------------------------------------------\
 -----------------------------------------------------\n");
         }
         if(dlinit){
@@ -1556,14 +1557,14 @@ restart:
       if(st_wit > 2*dlift->rr * stf4){
         dlift->rr = 2*dlift->rr;
         if(info_level){
-          fprintf(stdout, "(->%d)", dlift->rr);
-	        fflush(stdout);
+          fprintf(VERBSTREAM, "(->%d)", dlift->rr);
+	        fflush(VERBSTREAM);
         }
       }
       if(info_level){
         if(!(nprimes & (nprimes - 1))){
-          fprintf(stdout, "{%d}", nprimes);
-	      fflush(stdout);
+          fprintf(VERBSTREAM, "{%d}", nprimes);
+	      fflush(VERBSTREAM);
         }
       }
       apply = 0;
@@ -1578,8 +1579,8 @@ restart:
       }
       if(dlift->lstart != lstart){
         if(info_level){
-          fprintf(stdout, "<%.2f%%>", 100* (float)MIN((dlift->lstart + 1), (*modgbsp)->ld)/(*modgbsp)->ld);
-	      fflush(stdout);
+          fprintf(VERBSTREAM, "<%.2f%%>", 100* (float)MIN((dlift->lstart + 1), (*modgbsp)->ld)/(*modgbsp)->ld);
+	      fflush(VERBSTREAM);
         }
         lstart = dlift->lstart;
       }
@@ -1587,21 +1588,21 @@ restart:
       /* but then duplicated datas and others should be free-ed */
     }
     if (info_level){
-      fprintf(stdout, " \n-------------------------------------------------\
+      fprintf(VERBSTREAM, " \n-------------------------------------------------\
 -----------------------------------------------------\n");
     }
   }
   if(info_level){
     long nbits = max_bit_size_gb((*modgbsp));
-    fprintf(stdout,"\n\n---------- COMPUTATIONAL DATA -----------\n");
-    fprintf(stdout, "Max coeff. bitsize %16lu\n", (unsigned long) nbits);
-    fprintf(stdout, "#primes            %16lu\n", (unsigned long) nprimes);
-    fprintf(stdout, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
-    fprintf(stdout, "-----------------------------------------\n");
-    fprintf(stdout, "\n---------------- TIMINGS ----------------\n");
-    fprintf(stdout, "CRT     (elapsed)         %10.2f sec\n", st_crt);
-    fprintf(stdout, "ratrecon(elapsed)         %10.2f sec\n", st_rrec);
-    fprintf(stdout, "-----------------------------------------\n");
+    fprintf(VERBSTREAM,"\n\n---------- COMPUTATIONAL DATA -----------\n");
+    fprintf(VERBSTREAM, "Max coeff. bitsize %16lu\n", (unsigned long) nbits);
+    fprintf(VERBSTREAM, "#primes            %16lu\n", (unsigned long) nprimes);
+    fprintf(VERBSTREAM, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
+    fprintf(VERBSTREAM, "-----------------------------------------\n");
+    fprintf(VERBSTREAM, "\n---------------- TIMINGS ----------------\n");
+    fprintf(VERBSTREAM, "CRT     (elapsed)         %10.2f sec\n", st_crt);
+    fprintf(VERBSTREAM, "ratrecon(elapsed)         %10.2f sec\n", st_rrec);
+    fprintf(VERBSTREAM, "-----------------------------------------\n");
   }
 
   if(dlinit){
@@ -1769,7 +1770,7 @@ gb_modpoly_t *groebner_qq(
       return NULL;
   }
   if (success == 0) {
-      fprintf(stderr,"Bad input data, stopped computation.\n");
+      fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
       exit(1);
   }
 
@@ -1779,7 +1780,7 @@ gb_modpoly_t *groebner_qq(
   gb_modpoly_t *modgbsp = malloc(sizeof(gb_modpoly_t));
   modgbsp = core_groebner_qq(modgbsp, bs, msd, md, &err, field_char, print_gb);
   if (err) {
-      fprintf(stderr,"Problem with groebner_qq, stopped computation (%d).\n", err);
+      fprintf(ERRSTREAM,"Problem with groebner_qq, stopped computation (%d).\n", err);
       exit(1);
   }
 
@@ -1789,7 +1790,7 @@ gb_modpoly_t *groebner_qq(
   md->f4_ctime = ct1 - ct0;
   md->f4_rtime = rt1 - rt0;
 
-  get_and_print_final_statistics(stdout, md, bs);
+  get_and_print_final_statistics(VERBSTREAM, md, bs);
 
   /* free and clean up */
   free_mstrace(msd, md);
@@ -1817,7 +1818,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
   if (flags->files->out_file != NULL) {
     ofile = fopen(flags->files->out_file, "w+");
   } else {
-    ofile = stdout;
+    ofile = OUTSTREAM;
   }
   if (flags->print_gb == 1) {
     fprintf(ofile, "#Leading ideal data\n");
@@ -1857,7 +1858,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
       fclose(ofile);
     }
     else{
-      display_gbmodpoly_cf_qq(stdout, (*modgbsp), gens);
+      display_gbmodpoly_cf_qq(OUTSTREAM, (*modgbsp), gens);
     }
   }
   if(flags->print_gb == 1){
@@ -1867,7 +1868,7 @@ void print_msolve_gbtrace_qq(data_gens_ff_t *gens,
       fclose(ofile);
     }
     else{
-      display_lm_gbmodpoly_cf_qq(stdout, (*modgbsp), gens);
+      display_lm_gbmodpoly_cf_qq(OUTSTREAM, (*modgbsp), gens);
     }
   }
   gb_modpoly_clear((*modgbsp));
@@ -1936,7 +1937,7 @@ int64_t export_groebner_qq(
         return 1;
     }
     if (success == 0) {
-        fprintf(stderr, "Bad input data, stopped computation.\n");
+        fprintf(ERRSTREAM, "Bad input data, stopped computation.\n");
         exit(1);
     }
 
@@ -1948,7 +1949,7 @@ int64_t export_groebner_qq(
     core_groebner_qq(modgbsp, bs, msd, md, &err, field_char,
             2/* if set to 1, only the LM of the Gbs are correct */);
     if (err) {
-        fprintf(stderr, "Problem with groebner_qq, stopped computation.\n");
+        fprintf(ERRSTREAM, "Problem with groebner_qq, stopped computation.\n");
         exit(1);
     }
 
@@ -1958,7 +1959,7 @@ int64_t export_groebner_qq(
     md->f4_ctime = ct1 - ct0;
     md->f4_rtime = rt1 - rt0;
 
-    get_and_print_final_statistics(stdout, md, bs);
+    get_and_print_final_statistics(VERBSTREAM, md, bs);
 
     int64_t nterms  = export_results_from_groebner_qq(bld, blen, bexp,
             bcf, mallocp, elim_block_len, (*modgbsp));

--- a/src/msolve/lifting.c
+++ b/src/msolve/lifting.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "streams.h"
+
 #ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #endif
@@ -199,19 +201,19 @@ static inline void copy_modular_matrix(trace_det_fglm_mat_t trace_det,
     if(trace_det->num_mat == trace_det->mat_alloc ){
         int32_t old_alloc = trace_det->mat_alloc;
         trace_det->mat_alloc += newalloc;
-        size_t sz2 = sz * trace_det->mat_alloc; 
+        size_t sz2 = sz * trace_det->mat_alloc;
 
-        int32_t *tmp = (int32_t *)realloc(trace_det->modular_matrices, 
+        int32_t *tmp = (int32_t *)realloc(trace_det->modular_matrices,
                 sz2 * sizeof(int32_t));
         if(tmp == NULL){
-            fprintf(stderr, "Problem when allocating modular matrices (amount = %zu)\n", trace_det->mat_alloc * sz);
+            fprintf(ERRSTREAM, "Problem when allocating modular matrices (amount = %zu)\n", trace_det->mat_alloc * sz);
             exit(1);
         }
         for(int64_t i = sz*old_alloc; i < sz2; i++){
             tmp[i] = 0;
         }
         trace_det->modular_matrices = tmp;
-        trace_det->primes = flint_realloc(trace_det->primes, 
+        trace_det->primes = flint_realloc(trace_det->primes,
                 trace_det->mat_alloc * sizeof(mp_limb_t));
     }
 
@@ -226,13 +228,13 @@ static inline void copy_modular_matrix(trace_det_fglm_mat_t trace_det,
 
 static inline void trace_det_initset(trace_det_fglm_mat_t trace_det,
                                      uint32_t trace_mod, uint32_t det_mod,
-                                     uint32_t tridx, uint32_t detidx, 
-                                     sp_matfglm_t **mod_mat, 
-                                     int lift_matrix, 
-                                     int nlins, 
+                                     uint32_t tridx, uint32_t detidx,
+                                     sp_matfglm_t **mod_mat,
+                                     int lift_matrix,
+                                     int nlins,
                                      int32_t nv,
                                      uint32_t **lineqs_ptr,
-                                     uint32_t newalloc, 
+                                     uint32_t newalloc,
                                      mp_limb_t prime) {
   mpz_init_set_ui(trace_det->trace_crt, trace_mod);
   mpz_init_set_ui(trace_det->det_crt, det_mod);
@@ -416,10 +418,10 @@ static inline void crt_lift_dense_rows(mpz_t *rows, uint32_t *mod_rows,
 static inline void crt_lift_trace_det(trace_det_fglm_mat_t trace_det,
                                       uint32_t trace_mod, uint32_t det_mod,
                                       sp_matfglm_t *mod_mat,
-                                      uint32_t *lineqs, 
+                                      uint32_t *lineqs,
                                       param_t *nmod_param,
                                       mpz_t modulus, mpz_t prod,
-                                      uint32_t prime, 
+                                      uint32_t prime,
                                       int nthrds
                                       ) {
   mpz_CRT_ui(trace_det->trace_crt, trace_det->trace_crt, modulus, trace_mod,
@@ -440,8 +442,8 @@ static inline void crt_lift_trace_det(trace_det_fglm_mat_t trace_det,
   }
 
   for(uint32_t i = trace_det->w_checked; i < mod_mat->nrows; i++){
-      mpz_CRT_ui(trace_det->matmul_wcrt[i], trace_det->matmul_wcrt[i], modulus, 
-                 mod_mat->dense_mat[trace_det->matmul_indices[i]], prime, prod, 
+      mpz_CRT_ui(trace_det->matmul_wcrt[i], trace_det->matmul_wcrt[i], modulus,
+                 mod_mat->dense_mat[trace_det->matmul_indices[i]], prime, prod,
                  trace_det->tmp, 0);
   }
 }
@@ -479,16 +481,16 @@ static inline void build_linear_forms(mpz_t *mpz_linear_forms,
   for (int i = 0; i < nlins; i++) {
     int32_t nc = i * sz;
     int32_t nc2 = i * (sz + 1);
-    fprintf(stderr, " ===> (%d, %d) ", nc, sz);
-    mpz_out_str(stderr, 10, mpz_linear_forms[nc2 + sz]);
-    fprintf(stderr, "\n");
+    fprintf(ERRSTREAM, " ===> (%d, %d) ", nc, sz);
+    mpz_out_str(ERRSTREAM, 10, mpz_linear_forms[nc2 + sz]);
+    fprintf(ERRSTREAM, "\n");
     for (int j = 0; j < sz; j++) {
-      mpz_out_str(stderr, 10, mpz_linear_forms[nc2 + j]);
-      fprintf(stderr, " / ");
-      mpz_out_str(stderr, 10, mpz_linear_forms[nc2 + sz]);
-      fprintf(stderr, ", ");
+      mpz_out_str(ERRSTREAM, 10, mpz_linear_forms[nc2 + j]);
+      fprintf(ERRSTREAM, " / ");
+      mpz_out_str(ERRSTREAM, 10, mpz_linear_forms[nc2 + sz]);
+      fprintf(ERRSTREAM, ", ");
     }
-    fprintf(stderr, "\n");
+    fprintf(ERRSTREAM, "\n");
   }
 #endif
   mpz_clear(lcm);
@@ -535,7 +537,7 @@ static inline int rat_recon_array(mpz_t *res, mpz_t *crt, int32_t sz,
 static inline int rat_recon_trace_det(trace_det_fglm_mat_t trace_det,
                                       rrec_data_t recdata, mpz_t modulus,
                                       mpz_t rnum, mpz_t rden, mpz_t gden) {
-    
+
     if(trace_det->done_det > 1 && trace_det->done_trace > 1){
         return 1;
     }
@@ -577,9 +579,9 @@ static inline int rat_recon_trace_det(trace_det_fglm_mat_t trace_det,
             mpz_mul(trace_det->matmul_wqq[2*i + 1], trace_det->matmul_wqq[2*i + 1],
                     gden);
             mpz_gcd(gcd, trace_det->matmul_wqq[2*i], trace_det->matmul_wqq[2*i + 1]);
-            mpz_divexact(trace_det->matmul_wqq[2*i + 1], 
+            mpz_divexact(trace_det->matmul_wqq[2*i + 1],
                     trace_det->matmul_wqq[2*i + 1], gcd);
-            mpz_divexact(trace_det->matmul_wqq[2*i], 
+            mpz_divexact(trace_det->matmul_wqq[2*i],
                     trace_det->matmul_wqq[2*i], gcd);
             nlifted++;
         }
@@ -662,7 +664,7 @@ static inline int check_det(trace_det_fglm_mat_t trace_det, uint32_t det_mod,
   return (c == det_mod);
 }
 
-static inline int check_lifted_coeff(mpz_t num, mpz_t den, 
+static inline int check_lifted_coeff(mpz_t num, mpz_t den,
         uint32_t mod, uint32_t prime){
   uint32_t lc = mpz_fdiv_ui(den, prime);
   lc = mod_p_inverse_32(lc, prime);
@@ -674,13 +676,13 @@ static inline int check_lifted_coeff(mpz_t num, mpz_t den,
   return (c == mod);
 }
 
-static inline int check_trace_det_data(trace_det_fglm_mat_t trace_det, 
-        deg_t *maxrec, 
-        uint32_t trace_mod, 
-        uint32_t det_mod, 
+static inline int check_trace_det_data(trace_det_fglm_mat_t trace_det,
+        deg_t *maxrec,
+        uint32_t trace_mod,
+        uint32_t det_mod,
         uint32_t *modular_linear_forms,
-        sp_matfglm_t *mod_mat, 
-        int32_t prime, 
+        sp_matfglm_t *mod_mat,
+        int32_t prime,
         int lift_matrix){
   //checks if trace is lifted
   if (trace_det->done_trace && trace_det->done_trace < 2) {
@@ -709,9 +711,9 @@ static inline int check_trace_det_data(trace_det_fglm_mat_t trace_det,
               nvars_t n = i * sz;
               nvars_t n2 = i * (sz + 1);
               for(nvars_t j = 0; j < sz; j++){
-                  if(!check_lifted_coeff(trace_det->mpz_linear_forms[n2+j], 
-                             trace_det->mpz_linear_forms[n2+sz], 
-                             modular_linear_forms[n+j], 
+                  if(!check_lifted_coeff(trace_det->mpz_linear_forms[n2+j],
+                             trace_det->mpz_linear_forms[n2+sz],
+                             modular_linear_forms[n+j],
                              prime)){
                       trace_det->lin_lifted = 0;
                       return 0;
@@ -725,8 +727,8 @@ static inline int check_trace_det_data(trace_det_fglm_mat_t trace_det,
       int64_t sz = trace_det->nrows * trace_det->ncols * (trace_det->num_mat - 1);
       int32_t nr = trace_det->w_checked;
       for(deg_t i = trace_det->w_checked; i < trace_det->nlifted; i++){
-          if(check_lifted_coeff(trace_det->matmul_wqq[2*i], 
-                  trace_det->matmul_wqq[2*i+1], 
+          if(check_lifted_coeff(trace_det->matmul_wqq[2*i],
+                  trace_det->matmul_wqq[2*i+1],
                   trace_det->modular_matrices[sz + trace_det->matmul_indices[i]], prime)){
               trace_det->done_coeffs[i]++;
               if(trace_det->done_coeffs[i] > 0){
@@ -743,7 +745,7 @@ static inline int check_trace_det_data(trace_det_fglm_mat_t trace_det,
   return 0;
 }
 
-static inline int check_linear_forms(trace_det_fglm_mat_t trace_det, 
+static inline int check_linear_forms(trace_det_fglm_mat_t trace_det,
         uint32_t *modular_linear_forms,
         int32_t prime){
     int32_t nlins = trace_det->nlins;
@@ -753,9 +755,9 @@ static inline int check_linear_forms(trace_det_fglm_mat_t trace_det,
         nvars_t n = i *sz;
         nvars_t n2 = i * (sz + 1);
         for(int32_t j = 0; j < sz; j++){
-            int b = check_lifted_coeff(trace_det->mpz_linear_forms[n2 + j], 
+            int b = check_lifted_coeff(trace_det->mpz_linear_forms[n2 + j],
                     trace_det->mpz_linear_forms[n2+sz],
-                    modular_linear_forms[n], 
+                    modular_linear_forms[n],
                     prime);
             if(!b) return 0;
         }
@@ -763,17 +765,17 @@ static inline int check_linear_forms(trace_det_fglm_mat_t trace_det,
     return 1;
 }
 
-static inline void check_matrix(trace_det_fglm_mat_t trace_det, 
-        sp_matfglm_t *mod_mat, 
+static inline void check_matrix(trace_det_fglm_mat_t trace_det,
+        sp_matfglm_t *mod_mat,
         int32_t prime){
     int32_t nrows = trace_det->nrows;
     int32_t ncols = trace_det->ncols;
     for(int32_t row = 0; row < nrows; row++){
         int32_t sz = row * ncols;
         for(int32_t col = 0; col < ncols; col++){
-            int b = check_lifted_coeff(trace_det->dense_mat[sz + col], 
-                    trace_det->mat_denoms[row], 
-                    mod_mat->dense_mat[sz + col], 
+            int b = check_lifted_coeff(trace_det->dense_mat[sz + col],
+                    trace_det->mat_denoms[row],
+                    mod_mat->dense_mat[sz + col],
                     prime);
             if(!b){
                 trace_det->mat_lifted = 0;
@@ -785,7 +787,7 @@ static inline void check_matrix(trace_det_fglm_mat_t trace_det,
 }
 
 
-static inline void mulmat_reconstruct(trace_det_fglm_mat_t trace_det, 
+static inline void mulmat_reconstruct(trace_det_fglm_mat_t trace_det,
         mpz_t modulus){
     int32_t num_primes = trace_det->num_primes;
     fmpz_comb_init(trace_det->comb, trace_det->primes, num_primes);
@@ -796,7 +798,7 @@ static inline void mulmat_reconstruct(trace_det_fglm_mat_t trace_det,
     int32_t ncols = trace_det->ncols;
     int32_t sz = nrows * ncols;
 
-    fmpz_t y; 
+    fmpz_t y;
     fmpz_init(y);
     fmpz_t fmodulus;
     fmpz_init(fmodulus);
@@ -821,7 +823,7 @@ static inline void mulmat_reconstruct(trace_det_fglm_mat_t trace_det,
         for(int32_t i = 0; i < num_primes; i++){
             trace_det->residues[i] = (mp_limb_t)trace_det->modular_matrices[i*sz + elt];
         }
-        fmpz_multi_CRT_ui(y, trace_det->residues, 
+        fmpz_multi_CRT_ui(y, trace_det->residues,
                 trace_det->comb, trace_det->comb_temp, 0);
         boo = fmpq_reconstruct_fmpz(res, y, fmodulus);
         if(boo == 0) {
@@ -836,10 +838,10 @@ static inline void mulmat_reconstruct(trace_det_fglm_mat_t trace_det,
             mpz_set(trace_det->mat_denoms[row], lcm);
             mpz_set_ui(lcm, 1);
             for(int32_t nc = 0; nc < ncols; nc++){
-                mpz_divexact(rowdenoms[nc], trace_det->mat_denoms[row], 
+                mpz_divexact(rowdenoms[nc], trace_det->mat_denoms[row],
                         rowdenoms[nc]);
-                mpz_mul(trace_det->dense_mat[row*ncols + nc], 
-                        trace_det->dense_mat[row*ncols + nc], 
+                mpz_mul(trace_det->dense_mat[row*ncols + nc],
+                        trace_det->dense_mat[row*ncols + nc],
                         rowdenoms[nc]);
             }
             row++;
@@ -914,9 +916,9 @@ rat_recon_matfglm(mpq_matfglm_t mpq_mat, crt_mpz_matfglm_t crt_mat,
     }
 
     for(uint32_t j = 0; j < ncols; j++){
-        mpz_mul(mpq_mat->dense_mat[2 * c+ 2 * j], mpq_mat->dense_mat[2 * c+ 2 * j], 
+        mpz_mul(mpq_mat->dense_mat[2 * c+ 2 * j], mpq_mat->dense_mat[2 * c+ 2 * j],
                 mpq_mat->denoms[i]);
-        mpz_divexact(mpq_mat->dense_mat[2 * c + 2 * j], mpq_mat->dense_mat[2 * c + 2 * j], 
+        mpz_divexact(mpq_mat->dense_mat[2 * c + 2 * j], mpq_mat->dense_mat[2 * c + 2 * j],
                 mpq_mat->dense_mat[2 * c + 2 * j + 1]);
     }
     (*matrec)++;
@@ -929,7 +931,7 @@ rat_recon_matfglm(mpq_matfglm_t mpq_mat, crt_mpz_matfglm_t crt_mat,
 }
 
 
-static inline void check_matrix_and_linear_forms(mpq_matfglm_t mpq_mat, sp_matfglm_t *mod_mat, 
+static inline void check_matrix_and_linear_forms(mpq_matfglm_t mpq_mat, sp_matfglm_t *mod_mat,
         mpz_t *mpz_lin, uint32_t *mod_lin, const int nlins, const nvars_t nv,
         int *mat_lifted, int* lin_lifted, deg_t *oldmatrec_checked, deg_t *matrec_checked, const uint32_t prime){
     *oldmatrec_checked = *matrec_checked;

--- a/src/msolve/linear.c
+++ b/src/msolve/linear.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "streams.h"
+
 void (*set_linear_poly)(nvars_t nlins, uint32_t *lineqs, nvars_t *linvars,
                         ht_t *bht, int32_t *bexp_lm, bs_t *bs);
 
@@ -439,14 +441,14 @@ static inline void compute_modular_linear_forms(int nlins, nvars_t sz,
     }
   }
 #ifdef DEBUGLIFTMAT
-  fprintf(stderr, "\nModular linear forms (prime = %u)\n", prime);
+  fprintf(ERRSTREAM, "\nModular linear forms (prime = %u)\n", prime);
   for (int i = 0; i < nlins; i++) {
     nvars_t n = i * sz;
     nvars_t n2 = i * (sz + 1);
     for (int j = 0; j < sz; j++) {
-      fprintf(stderr, "%d, ", mod_linear_forms[n + j]);
+      fprintf(ERRSTREAM, "%d, ", mod_linear_forms[n + j]);
     }
-    fprintf(stderr, "\n");
+    fprintf(ERRSTREAM, "\n");
   }
 #endif
 }

--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "libmsolve.c"
+#include "streams.h"
 
 #define DEBUGGB 0
 #define DEBUGBUILDMATRIX 0
@@ -27,31 +28,32 @@
 #define LONG_OPT_LENGTH 15
 #define ARG_OPT_LENGTH 4
 
+
 static inline void display_option_help(char short_opt, char *long_opt,
 				       char *arg_opt, char* str) {
   int long_opt_non_empty= strcmp (long_opt, "");
 
   if (short_opt == 0) {
-    fprintf (stdout, "    ");
+    fprintf (OUTSTREAM, "    ");
   } else {
-    fprintf (stdout, "-%c", short_opt);
+    fprintf (OUTSTREAM, "-%c", short_opt);
     if (long_opt_non_empty) {
-      fprintf (stdout, ", ");
+      fprintf (OUTSTREAM, ", ");
     } else {
-      fprintf (stdout, "  ");
+      fprintf (OUTSTREAM, "  ");
     }
   }
 
   if (long_opt_non_empty) {
-    fprintf (stdout, "--");
+    fprintf (OUTSTREAM, "--");
   } else {
-    fprintf (stdout, "  ");
+    fprintf (OUTSTREAM, "  ");
   }
-  fprintf (stdout, "%-*s ",
+  fprintf (OUTSTREAM, "%-*s ",
 	   LONG_OPT_LENGTH, long_opt);
-  fprintf (stdout, "%-*s  ",
+  fprintf (OUTSTREAM, "%-*s  ",
 	   ARG_OPT_LENGTH, arg_opt);
-  fprintf (stdout, "%s", str);
+  fprintf (OUTSTREAM, "%s", str);
 }
 
 static inline void display_option_help_noopt(char* str) {
@@ -59,16 +61,16 @@ static inline void display_option_help_noopt(char* str) {
 }
 
 static inline void display_help(char *str){
-  fprintf(stdout, "\nmsolve library for polynomial system solving, version %s\n", VERSION);
-  fprintf(stdout, "implemented by J. Berthomieu, C. Eder, M. Safey El Din\n");
-  fprintf(stdout, "\n");
-  /* fprintf(stdout, "commit hash: %s\n\n", GIT_COMMIT_HASH); */
+  fprintf(OUTSTREAM, "\nmsolve library for polynomial system solving, version %s\n", VERSION);
+  fprintf(OUTSTREAM, "implemented by J. Berthomieu, C. Eder, M. Safey El Din\n");
+  fprintf(OUTSTREAM, "\n");
+  /* fprintf(OUTSTREAM, "commit hash: %s\n\n", GIT_COMMIT_HASH); */
 
-  fprintf(stdout, "Basic call:\n");
-  fprintf(stdout, "\t ./msolve -f [FILE1] -o [FILE2]\n\n");
-  fprintf(stdout, "FILE1 and FILE2 are respectively the input and output files\n\n");
+  fprintf(OUTSTREAM, "Basic call:\n");
+  fprintf(OUTSTREAM, "\t ./msolve -f [FILE1] -o [FILE2]\n\n");
+  fprintf(OUTSTREAM, "FILE1 and FILE2 are respectively the input and output files\n\n");
 
-  fprintf(stdout, "Standard options\n\n");
+  fprintf(OUTSTREAM, "Standard options\n\n");
   display_option_help('f', "file", "FILE", "File name (mandatory).\n\n");
   display_option_help('h', "help", "", "Prints this help.\n");
   display_option_help('o', "output-file", "FILE",  "Name of output file.\n");
@@ -82,23 +84,23 @@ static inline void display_help(char *str){
   display_option_help_noopt("2 - detailed output for each step of the\n");
   display_option_help_noopt("    algorithm, e.g. matrix sizes, #pairs, ...\n");
 
-  fprintf(stdout, "Input file format:\n");
-  fprintf(stdout, "\t - first line: variables separated by a comma\n");
-  fprintf(stdout, "\t                (no comma at end of line)\n");
-  fprintf(stdout, "\t - second line: characteristic of the field\n");
-  fprintf(stdout, "\t - next lines provide the polynomials (one per line),\n");
-  fprintf(stdout, "\t   separated by a comma\n");
-  fprintf(stdout, "\t   (no comma after the last polynomial)\n\n");
-  fprintf(stdout, "Output file format: \n");
-  fprintf(stdout, "When there is no solution in an algebraic closure of the base field\n[-1]:\n");
-  fprintf(stdout, "Where there are infinitely many solutions in \nan algebraic closure of the base field: \n[1, nvars, -1,[]]:\n");
-  fprintf(stdout,"Else:\n");
-  fprintf(stdout,"Over prime fields: a rational parametrization of the solutions\n");
-  fprintf(stdout,"When input coefficients are rational numbers: \nreal solutions to the input system (see the -P flag to recover a parametrization of the solutions)\n");
-  fprintf(stdout, "See the msolve tutorial for more details (https://msolve.lip6.fr)\n");
+  fprintf(OUTSTREAM, "Input file format:\n");
+  fprintf(OUTSTREAM, "\t - first line: variables separated by a comma\n");
+  fprintf(OUTSTREAM, "\t                (no comma at end of line)\n");
+  fprintf(OUTSTREAM, "\t - second line: characteristic of the field\n");
+  fprintf(OUTSTREAM, "\t - next lines provide the polynomials (one per line),\n");
+  fprintf(OUTSTREAM, "\t   separated by a comma\n");
+  fprintf(OUTSTREAM, "\t   (no comma after the last polynomial)\n\n");
+  fprintf(OUTSTREAM, "Output file format: \n");
+  fprintf(OUTSTREAM, "When there is no solution in an algebraic closure of the base field\n[-1]:\n");
+  fprintf(OUTSTREAM, "Where there are infinitely many solutions in \nan algebraic closure of the base field: \n[1, nvars, -1,[]]:\n");
+  fprintf(OUTSTREAM,"Else:\n");
+  fprintf(OUTSTREAM,"Over prime fields: a rational parametrization of the solutions\n");
+  fprintf(OUTSTREAM,"When input coefficients are rational numbers: \nreal solutions to the input system (see the -P flag to recover a parametrization of the solutions)\n");
+  fprintf(OUTSTREAM, "See the msolve tutorial for more details (https://msolve.lip6.fr)\n");
 
 
-  fprintf(stdout, "\nAdvanced options:\n\n");
+  fprintf(OUTSTREAM, "\nAdvanced options:\n\n");
   display_option_help('F', "", "FILE", "File name encoding parametrizations in binary format.\n\n");
   display_option_help('g', "groebner-basis", "GB", "Prints reduced Groebner bases of input system for\n");
   display_option_help_noopt("first prime characteristic w.r.t. grevlex ordering.\n");
@@ -279,7 +281,7 @@ static void getoptions(
       display_help(argv[0]);
       exit(0);
     case 'V':
-      fprintf(stdout, "%s\n", VERSION);
+      fprintf(OUTSTREAM, "%s\n", VERSION);
       exit(0);
     case 'e':
       *elim_block_len = strtol(optarg, NULL, 10);
@@ -419,12 +421,12 @@ static void getoptions(
     }
   }
   if(fflag){
-    fprintf(stderr,"No given file\n");
+    fprintf(ERRSTREAM,"No given file\n");
     display_help(argv[0]);
     exit(1);
   }
   if(errflag){
-    fprintf(stderr, "Invalid usage\n");
+    fprintf(ERRSTREAM, "Invalid usage\n");
     display_help(argv[0]);
     exit(1);
   }
@@ -478,7 +480,8 @@ int main(int argc, char **argv){
     files->bin_out_file = NULL;
     getoptions(argc, argv, &initial_hts, &nr_threads, &max_pairs,
                &elim_block_len, &la_option, &use_signatures, &update_ht,
-               &reduce_gb, &print_gb, &truncate_lifting, &genericity_handling, &unstable_staircase, &saturate, &colon,
+               &reduce_gb, &print_gb, &truncate_lifting, &genericity_handling,
+               &unstable_staircase, &saturate, &colon,
                &normal_form, &normal_form_matrix, &is_gb, &lift_matrix, &get_param,
                &precision, &refine, &isolate, &generate_pbm,
 	       &seed, &info_level, files);
@@ -492,8 +495,8 @@ int main(int argc, char **argv){
     }
     srand(true_seed);
     if (info_level) {
-      fprintf (stdout,"Initial seed for pseudo-random number generator ");
-      fprintf (stdout,"is %u\n",true_seed);
+      fprintf (VERBSTREAM,"Initial seed for pseudo-random number generator ");
+      fprintf (VERBSTREAM,"is %u\n",true_seed);
     }
 
     FILE *fh = NULL;
@@ -506,7 +509,7 @@ int main(int argc, char **argv){
     }
 
     if (fh == NULL && bfh == NULL) {
-      fprintf(stderr, "Input file not found.\n");
+      fprintf(ERRSTREAM, "Input file not found.\n");
       exit(1);
     }
     if(fh!=NULL){
@@ -522,7 +525,7 @@ int main(int argc, char **argv){
     if(files->out_file != NULL){
       FILE *ofile = fopen(files->out_file, "w");
       if(ofile == NULL){
-        fprintf(stderr, "Cannot open output file\n");
+        fprintf(ERRSTREAM, "Cannot open output file\n");
         exit(1);
       }
       fclose(ofile);
@@ -538,7 +541,7 @@ int main(int argc, char **argv){
 
     get_data_from_file(files->in_file, &nr_vars, &field_char, &nr_gens, gens);
 #ifdef IODEBUG
-    display_gens(stdout, gens);
+    display_gens(VERBSTREAM, gens);
 #endif
 
     gens->rand_linear           = 0;
@@ -547,8 +550,8 @@ int main(int argc, char **argv){
 
     if(0 < field_char && field_char < pow(2, 15) && la_option > 2){
         if(info_level){
-            fprintf(stderr, "Warning: characteristic is too low for choosing \nprobabilistic linear algebra\n");
-            fprintf(stderr, "\t linear algebra option set to 2\n");
+            fprintf(ERRSTREAM, "Warning: characteristic is too low for choosing \nprobabilistic linear algebra\n");
+            fprintf(ERRSTREAM, "\t linear algebra option set to 2\n");
         }
         la_option = 2;
     }
@@ -565,11 +568,14 @@ int main(int argc, char **argv){
     /* main msolve functionality */
     int ret = core_msolve(la_option, use_signatures, nr_threads, info_level,
                           initial_hts, max_pairs, elim_block_len, update_ht,
-                          generate_pbm, reduce_gb, print_gb, truncate_lifting, get_param,
-                          genericity_handling, unstable_staircase, saturate, colon, normal_form,
+                          generate_pbm, reduce_gb, print_gb, truncate_lifting,
+                          get_param,
+                          genericity_handling, unstable_staircase, saturate,
+                          colon, normal_form,
                           normal_form_matrix, is_gb, lift_matrix, precision,
                           files, gens,
-            &param, mpz_paramp, &nb_real_roots, &real_roots, &real_pts);
+                          &param, mpz_paramp, &nb_real_roots, &real_roots,
+                          &real_pts);
 
     /* free parametrization */
     if(param != NULL && gens->field_char){
@@ -591,11 +597,11 @@ int main(int argc, char **argv){
     if (info_level > 0) {
         double st1 = cputime();
         double rt1 = realtime();
-        fprintf(stdout, "\n\n-------------------------------------------------\
+        fprintf(VERBSTREAM, "\n\n-------------------------------------------------\
 -----------------------------------\n");
-        fprintf(stdout, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
+        fprintf(VERBSTREAM, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
                 rt1-rt0, st1-st0);
-        fprintf(stdout, "-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 -----------------------------------\n");
     }
     free_data_gens(gens);

--- a/src/msolve/main.c
+++ b/src/msolve/main.c
@@ -19,7 +19,6 @@
  * Mohab Safey El Din */
 
 #include "libmsolve.c"
-#include "streams.h"
 
 #define DEBUGGB 0
 #define DEBUGBUILDMATRIX 0

--- a/src/msolve/msolve-data.h
+++ b/src/msolve/msolve-data.h
@@ -331,6 +331,7 @@ typedef struct{
   char *bin_file;
   char *out_file;
   char *bin_out_file;
+  char *verb_file;
 } files_gb;
 
 /* data structure for tracing algorithms */

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -19,10 +19,12 @@
  * Mohab Safey El Din */
 
 #include "msolve.h"
+#include "streams.h"
 #include "duplicate.c"
 #include "linear.c"
 #include "lifting.c"
 #include "lifting-gb.c"
+#include "streams.h"
 
 #ifndef MAX
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
@@ -39,7 +41,7 @@ static void mpz_upoly_init(mpz_upoly_t poly, deg_t alloc) {
   if (alloc) {
     tmp = (mpz_t *)(malloc(alloc * sizeof(mpz_t)));
     if (tmp == NULL) {
-      fprintf(stderr, "Unable to allocate in mpz_upoly_init\n");
+      fprintf(ERRSTREAM, "Unable to allocate in mpz_upoly_init\n");
       exit(1);
     }
     for (deg_t i = 0; i < alloc; i++) {
@@ -57,7 +59,7 @@ static void mpz_upoly_init2(mpz_upoly_t poly, deg_t alloc, bits_t nbits) {
   if (alloc) {
     tmp = (mpz_t *)(malloc(alloc * sizeof(mpz_t)));
     if (tmp == NULL) {
-      fprintf(stderr, "Unable to allocate in mpz_upoly_init\n");
+      fprintf(ERRSTREAM, "Unable to allocate in mpz_upoly_init\n");
       exit(1);
     }
     for (deg_t i = 0; i < alloc; i++) {
@@ -496,11 +498,11 @@ static int change_variable_order_in_input_system(data_gens_ff_t *gens,
     len += gens->lens[i] * nvars;
   }
   if (info_level > 0) {
-    printf("\nChanging variable order for possibly more generic staircase:\n");
+    fprintf(VERBSTREAM, "\nChanging variable order for possibly more generic staircase:\n");
     for (int i = 0; i < nvars - 1; i++) {
-      fprintf(stdout, "%s, ", gens->vnames[i]);
+      fprintf(VERBSTREAM, "%s, ", gens->vnames[i]);
     }
-    fprintf(stdout, "%s\n", gens->vnames[nvars - 1]);
+    fprintf(VERBSTREAM, "%s\n", gens->vnames[nvars - 1]);
   }
   return 1;
 }
@@ -586,9 +588,9 @@ static int add_linear_form_to_input_system(data_gens_ff_t *gens,
   const int32_t bcf = gens->linear_form_base_coef;
   k = 1;
   if (info_level > 0) {
-    printf("\nAdding a linear form with an extra variable ");
-    printf("(lowest w.r.t. monomial order)\n");
-    printf("[coefficients of linear form are k^%d for k looping over variable "
+    fprintf(VERBSTREAM, "\nAdding a linear form with an extra variable ");
+    fprintf(VERBSTREAM, "(lowest w.r.t. monomial order)\n");
+    fprintf(VERBSTREAM, "[coefficients of linear form are k^%d for k looping over variable "
            "index 1...n]\n",
            bcf - 1);
   }
@@ -684,9 +686,9 @@ static int add_random_linear_form_to_input_system(data_gens_ff_t *gens,
   gens->linear_form_base_coef++;
   /* const int32_t bcf = gens->linear_form_base_coef; */
   if (info_level > 0) {
-    printf("\nAdding a linear form with an extra variable ");
-    printf("(lowest w.r.t. monomial order)\n");
-    printf("[coefficients of linear form are randomly chosen]\n");
+    fprintf(VERBSTREAM, "\nAdding a linear form with an extra variable ");
+    fprintf(VERBSTREAM, "(lowest w.r.t. monomial order)\n");
+    fprintf(VERBSTREAM, "[coefficients of linear form are randomly chosen]\n");
   }
   /* gens->random_linear_form = malloc(sizeof(int32_t)*(nvars_new)); */
   gens->random_linear_form =
@@ -781,7 +783,7 @@ static inline void initialize_mpz_param(mpz_param_t param, param_t *bparam) {
       param->coords[i]->length = bparam->elim->length - 1;
     }
   } else {
-    fprintf(stderr, "Error when initializing parametrization\n");
+    fprintf(ERRSTREAM, "Error when initializing parametrization\n");
     exit(1);
   }
   param->cfs = (mpz_t *)malloc(sizeof(mpz_t) * (param->nvars - 1));
@@ -791,7 +793,7 @@ static inline void initialize_mpz_param(mpz_param_t param, param_t *bparam) {
       mpz_set_ui(param->cfs[i], 1);
     }
   } else {
-    fprintf(stderr, "Error when allocating cfs\n");
+    fprintf(ERRSTREAM, "Error when allocating cfs\n");
     exit(1);
   }
 }
@@ -1151,7 +1153,7 @@ static inline void lift_coordinate(mpz_param_t mpz_param, mpz_param_t tmp_mpz_pa
                       mpz_param->coords[idx]->coeffs[j], mpq_numref(c));
             }
             if(info_level){
-                fprintf(stdout, "[%d]", idx + 1);
+                fprintf(VERBSTREAM, "[%d]", idx + 1);
             }
         }
       }
@@ -1183,7 +1185,7 @@ static inline int lift_parametrization(mpz_param_t mpz_param, mpz_param_t tmp_mp
       }
       is_lifted[0] = 1;
       if (info_level) {
-        fprintf(stdout, "[0]");
+        fprintf(VERBSTREAM, "[0]");
       }
 
     }
@@ -1487,8 +1489,8 @@ static inline int check_param_modular(const mpz_param_t mp_param,
   int c = check_unit_mpz_nmod_poly(len, mp_param->elim, bparam->elim, prime);
   if (c) {
     if (info_level) {
-      fprintf(stdout, "<0,%d>", c);
-      fflush(stdout);
+      fprintf(VERBSTREAM, "<0,%d>", c);
+      fflush(VERBSTREAM);
     }
     is_lifted[0] = 0;
     for (int i = 0; i < mp_param->nvars - 1; i++) {
@@ -1516,8 +1518,8 @@ static inline int check_param_modular(const mpz_param_t mp_param,
             mp_param->elim->length - 1, bparam->coords[i], prime)) {
       is_lifted[i + 1] = 0;
       if (info_level) {
-        fprintf(stdout, "<%d>", i + 1);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "<%d>", i + 1);
+        fflush(VERBSTREAM);
       }
       return 1;
     }
@@ -1555,7 +1557,7 @@ static int32_t check_for_single_element_groebner_basis(
 
   if (bs->lml == 1) {
     if (md->info_level > 0) {
-      fprintf(stdout, "Grobner basis has a single element\n");
+      fprintf(VERBSTREAM, "Grobner basis has a single element\n");
     }
     for (i = 0; i < bs->ht->nv; i++) {
       if (leadmons[pos][i] != 0) {
@@ -1567,7 +1569,7 @@ static int32_t check_for_single_element_groebner_basis(
       *dquot_ori = 0;
       *dim = 0;
       if (md->info_level > 0) {
-        fprintf(stdout, "No solution\n");
+        fprintf(VERBSTREAM, "No solution\n");
       }
     }
   } else {
@@ -1630,7 +1632,7 @@ static int32_t *initial_modular_step(
     bs_t *bs = core_gba(gbg, md, &error, fc);
 
     md->learning_rtime = realtime()-rt;
-    print_tracer_statistics(stdout, rt, md);
+    print_tracer_statistics(VERBSTREAM, rt, md);
 
     get_leading_ideal_information(num_gb, leadmons, 0, bs);
 
@@ -1654,7 +1656,7 @@ static int32_t *initial_modular_step(
         int32_t *lmb = monomial_basis(bs->lml, bs->ht->nv, leadmons[0], &dquot);
 
         /* if(md->info_level){ */
-        /*     fprintf(stderr, "Dimension of quotient: %ld\n", dquot); */
+        /*     fprintf(ERRSTREAM, "Dimension of quotient: %ld\n", dquot); */
         /* } */
         if(print_gb==0){
             /* *bmatrix = build_matrixn_from_bs_trace(bdiv_xn, */
@@ -1666,7 +1668,7 @@ static int32_t *initial_modular_step(
             /* 					 md->info_level); */
             md->fglm_rtime = realtime();
             md->fglm_ctime = cputime();
-            print_fglm_header (stdout,md);
+            print_fglm_header (VERBSTREAM,md);
             *bmatrix = build_matrixn_unstable_from_bs_trace(bdiv_xn,
                                                             blen_gb_xn,
                                                             bstart_cf_gb_xn,
@@ -1686,7 +1688,7 @@ static int32_t *initial_modular_step(
                 *dim = 0;
                 *dquot_ori = dquot;
                 if(md->info_level > 1){
-                    fprintf (stdout,"------------------------------------------------------------------------------------------------------\n");
+                    fprintf (VERBSTREAM,"------------------------------------------------------------------------------------------------------\n");
                 }
                 free_basis_without_hash_table(&(bs));
                 free(bs);
@@ -2193,7 +2195,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 
   /* all data is corrupt */
   if (res == -1) {
-    fprintf(stderr, "Invalid input generators, msolve now terminates.\n");
+    fprintf(ERRSTREAM, "Invalid input generators, msolve now terminates.\n");
     free(st);
     free(invalid_gens);
     return -3;
@@ -2224,7 +2226,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
   //free(invalid_gens);
   invalid_gens = NULL;
 
-  print_initial_statistics(stdout, st);
+  print_initial_statistics(VERBSTREAM, st);
 
   /* for faster divisibility checks, needs to be done after we have
    * read some input data for applying heuristics */
@@ -2265,7 +2267,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
   primeinit = prime;
   lp->p[0] = primeinit;
   if(info_level && gens->field_char == 0){
-      fprintf(stdout, "Initial prime is %d\n", lp->p[0]);
+      fprintf(VERBSTREAM, "Initial prime is %d\n", lp->p[0]);
   }
 
   if (gens->field_char) {
@@ -2418,7 +2420,7 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
     }
     if (*dim_ptr == 1) {
       if (info_level) {
-        fprintf(stdout, "Positive dimensional Grobner basis\n");
+        fprintf(VERBSTREAM, "Positive dimensional Grobner basis\n");
       }
       free_msolve_trace_qq_initial_data(invalid_gens, st, lp, bs_qq, bs, nmod_params,
           bad_primes, bmatrix, bdiv_xn, blen_gb_xn, bstart_cf_gb_xn, bextra_nf,
@@ -2639,44 +2641,44 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
 
     if (nprimes == 1) {
       if (info_level > 2) {
-        fprintf(stdout, "------------------------------------------\n");
-        fprintf(stdout, "#ADDITIONS       %13lu\n",
+        fprintf(VERBSTREAM, "------------------------------------------\n");
+        fprintf(VERBSTREAM, "#ADDITIONS       %13lu\n",
                 (unsigned long)st->application_nr_add * 1000);
-        fprintf(stdout, "#MULTIPLICATIONS %13lu\n",
+        fprintf(VERBSTREAM, "#MULTIPLICATIONS %13lu\n",
                 (unsigned long)st->application_nr_mult * 1000);
-        fprintf(stdout, "#REDUCTIONS      %13lu\n",
+        fprintf(VERBSTREAM, "#REDUCTIONS      %13lu\n",
                 (unsigned long)st->application_nr_red);
-        fprintf(stdout, "------------------------------------------\n");
-        fflush(stdout);
+        fprintf(VERBSTREAM, "------------------------------------------\n");
+        fflush(VERBSTREAM);
       }
       if(info_level){
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "\n---------------- TIMINGS ----------------\n");
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "multi-mod overall(elapsed) %9.2f sec\n",
 		    ca1);
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "multi-mod F4               %9.2f sec\n",
 		    stf4);
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "multi-mod FGLM             %9.2f sec\n",
 		    ca1-stf4);
 	    if (info_level > 1){
-	      fprintf(stdout,
+	      fprintf(VERBSTREAM,
 		      "learning phase             %9.2f Gops/sec\n",
 		      (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(st->learning_rtime));
-	      fprintf(stdout,
+	      fprintf(VERBSTREAM,
 		      "application phase          %9.2f Gops/sec\n",
 		      (st->application_nr_add+st->application_nr_mult)/1000.0/1000.0/(stf4));
 	    }
-	    fprintf(stdout,
+	    fprintf(VERBSTREAM,
 		    "-----------------------------------------\n");
-        fflush(stdout);
+        fflush(VERBSTREAM);
       }
       if (info_level) {
-	  fprintf(stdout,
+	  fprintf(VERBSTREAM,
 		  "\nmulti-modular steps\n");
-	  fprintf(stdout, "-------------------------------------------------\
+	  fprintf(VERBSTREAM, "-------------------------------------------------\
 -----------------------------------------------------\n");
       }
 
@@ -2719,8 +2721,8 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
         nprimes++;
       } else {
         if (info_level) {
-          fprintf(stdout, "<bp: %d>\n", lp->p[i]);
-	      fflush(stdout);
+          fprintf(VERBSTREAM, "<bp: %d>\n", lp->p[i]);
+	      fflush(VERBSTREAM);
         }
         nbadprimes++;
         if (nbadprimes > nprimes) {
@@ -2744,8 +2746,8 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
       lpow2 = 2 * nprimes;
       doit = 0;
       if (info_level) {
-        fprintf(stdout, "\n<Step:%d/%.2f/%.2f>", nbdoit, scrr, t);
-    	fflush(stdout);
+        fprintf(VERBSTREAM, "\n<Step:%d/%.2f/%.2f>", nbdoit, scrr, t);
+    	fflush(VERBSTREAM);
       }
     }
     prdone++;
@@ -2753,8 +2755,8 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
     if ((LOG2(nprimes) > clog) ||
         (nbdoit != 1 && (nprimes % (lpow2 + 1) == 0))) {
       if (info_level) {
-        fprintf(stdout, "{%d}", nprimes);
-	fflush(stdout);
+        fprintf(VERBSTREAM, "{%d}", nprimes);
+	fflush(VERBSTREAM);
       }
       clog++;
       lpow2 = 2 * lpow2;
@@ -2769,21 +2771,21 @@ int msolve_trace_qq(mpz_param_t *mpz_paramp,
                (*mpz_paramp)->denom->coeffs[i - 1], i);
   }
   if(info_level){
-    fprintf(stdout,
+    fprintf(VERBSTREAM,
 	    "\n-------------------------------------------------\
 -----------------------------------------------------\n");
   }
 
 
   if(info_level){
-    fprintf(stdout,"\n---------- COMPUTATIONAL DATA -----------\n");
-    fprintf(stdout, "#primes            %16lu\n", (unsigned long) nprimes);
-    fprintf(stdout, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
-    fprintf(stdout, "-----------------------------------------\n");
-    fprintf(stdout, "\n---------------- TIMINGS ----------------\n");
-    fprintf(stdout, "CRT and ratrecon(elapsed) %10.2f sec\n", strat);
-    fprintf(stdout, "-----------------------------------------\n");
-    fflush(stdout);
+    fprintf(VERBSTREAM,"\n---------- COMPUTATIONAL DATA -----------\n");
+    fprintf(VERBSTREAM, "#primes            %16lu\n", (unsigned long) nprimes);
+    fprintf(VERBSTREAM, "#bad primes        %16lu\n", (unsigned long) nbadprimes);
+    fprintf(VERBSTREAM, "-----------------------------------------\n");
+    fprintf(VERBSTREAM, "\n---------------- TIMINGS ----------------\n");
+    fprintf(VERBSTREAM, "CRT and ratrecon(elapsed) %10.2f sec\n", strat);
+    fprintf(VERBSTREAM, "-----------------------------------------\n");
+    fflush(VERBSTREAM);
   }
   free_msolve_trace_qq_initial_data(invalid_gens, st, lp, bs_qq, bs, nmod_params,
               bad_primes, bmatrix, bdiv_xn, blen_gb_xn, bstart_cf_gb_xn, bextra_nf,
@@ -3047,9 +3049,9 @@ void generate_table_values_full_large_pos(mpz_t numer, mpz_t c, const long k, co
         mpz_cdiv_q_2exp(xup[i], xup[i], newcorr);
 
         if(mpz_cmp(xup[i], xdo[i])<0){
-            fprintf(stderr, "BUG in generate (debut %ld)\n", i);
-            mpz_out_str(stderr, 10, xdo[i]);fprintf(stderr, "\n");
-            mpz_out_str(stderr, 10, xup[i]);fprintf(stderr, "\n");
+            fprintf(ERRSTREAM, "BUG in generate (debut %ld)\n", i);
+            mpz_out_str(ERRSTREAM, 10, xdo[i]);fprintf(ERRSTREAM, "\n");
+            mpz_out_str(ERRSTREAM, 10, xup[i]);fprintf(ERRSTREAM, "\n");
             exit(1);
         }
     }
@@ -3081,7 +3083,7 @@ void generate_table_values_full_large_pos(mpz_t numer, mpz_t c, const long k, co
         mpz_fdiv_q_2exp(xdo[i], xdo[i], newcorr);
         mpz_cdiv_q_2exp(xup[i], xup[i], newcorr);
         if(mpz_cmp(xup[i], xdo[i])<0){
-            fprintf(stderr, "BUG in generate (end)\n");
+            fprintf(ERRSTREAM, "BUG in generate (end)\n");
             exit(1);
         }
     }
@@ -3213,7 +3215,7 @@ int newvalue_denom_old(mpz_t *denom, long deg, mpz_t r, long k, mpz_t *xdo,
   /*boo = 1 if sgn(den_do) != sgn(den_up) else it is 0*/
   int boo = mpz_poly_eval_interval(denom, deg, k, r, c, tmp, den_do, den_up);
   if (mpz_cmp(den_do, den_up) > 0) {
-    fprintf(stderr, "BUG (den_do > den_up)\n");
+    fprintf(ERRSTREAM, "BUG (den_do > den_up)\n");
     exit(1);
   }
   return (boo || (mpz_sgn(den_do)==0) || (mpz_sgn(den_up)==0));
@@ -3234,7 +3236,7 @@ void refine_root_elim(mpz_param_t param, mpz_t *polelim, long ns, interval *rt, 
     if (mpz_sgn(rt->numer) >= 0) {
       get_values_at_bounds(param->elim->coeffs, ns, rt, tab);
       if(mpz_sgn(tab[0]) != rt->sign_left){
-          fprintf(stderr, "BUG in get_values_at_bounds (called from refine_root_elim)\n");
+          fprintf(ERRSTREAM, "BUG in get_values_at_bounds (called from refine_root_elim)\n");
           exit(1);
       }
       refine_QIR_positive_root(polelim, &ns, rt, tab, 2 * (rt->k), info_level);
@@ -3420,7 +3422,7 @@ void lazy_single_real_root_param(mpz_param_t param, mpz_t *polelim,
         &b, info_level);
 
     if (info_level) {
-      fprintf(stdout, "<%ld>", rt->k);
+      fprintf(VERBSTREAM, "<%ld>", rt->k);
     }
   }
   if (rt->isexact == 1) {
@@ -3584,8 +3586,8 @@ void extract_real_roots_param(mpz_param_t param, interval *roots, long nb,
 
     if (info_level) {
       if (realtime() - et >= step) {
-        fprintf(stdout, "{%.2f%%}", 100 * nc / ((double)nb));
-        fflush(stdout);
+        fprintf(VERBSTREAM, "{%.2f%%}", 100 * nc / ((double)nb));
+        fflush(VERBSTREAM);
         et = realtime();
       }
     }
@@ -3630,22 +3632,22 @@ real_point_t *isolate_real_roots_param(mpz_param_t param, long *nb_real_roots_pt
       mpz_poly_max_bsize_coeffs(param->elim->coeffs, param->elim->length - 1);
 
   if(info_level){
-      fprintf(stdout, "Maximum bit size in elimination polynomial: %ld\n", maxnbits);
-      fprintf(stdout, "Maximum bit size of coeffs in parametrizations: [");
-      fflush(stdout);
+      fprintf(VERBSTREAM, "Maximum bit size in elimination polynomial: %ld\n", maxnbits);
+      fprintf(VERBSTREAM, "Maximum bit size of coeffs in parametrizations: [");
+      fflush(VERBSTREAM);
   }
   for (int i = 0; i < param->nvars - 1; i++) {
     long cmax = mpz_poly_max_bsize_coeffs(param->coords[i]->coeffs,
                                           param->coords[i]->length - 1);
     if(info_level){
-        fprintf(stdout, "%ld",cmax);
+        fprintf(VERBSTREAM, "%ld",cmax);
         if(i == param->nvars - 2){
-            fprintf(stdout, "]\n");
-            fflush(stdout);
+            fprintf(VERBSTREAM, "]\n");
+            fflush(VERBSTREAM);
         }
         else{
-            fprintf(stdout, ", ");
-            fflush(stdout);
+            fprintf(VERBSTREAM, ", ");
+            fflush(VERBSTREAM);
         }
     }
     maxnbits = MAX(cmax, maxnbits);
@@ -3662,14 +3664,14 @@ real_point_t *isolate_real_roots_param(mpz_param_t param, long *nb_real_roots_pt
 
   real_point_t *pts = NULL;
   if (info_level > 0) {
-    fprintf(stdout, "Number of real roots: %ld\n", nb);
-    fflush(stdout);
+    fprintf(VERBSTREAM, "Number of real roots: %ld\n", nb);
+    fflush(VERBSTREAM);
   }
   if (nb) {
     /* */
     if (info_level) {
-      fprintf(stdout, "Starts real root extraction.\n");
-      fflush(stdout);
+      fprintf(VERBSTREAM, "Starts real root extraction.\n");
+      fflush(VERBSTREAM);
     }
     double st = realtime();
     pts = malloc(sizeof(real_point_t) * nb);
@@ -3681,9 +3683,9 @@ real_point_t *isolate_real_roots_param(mpz_param_t param, long *nb_real_roots_pt
     extract_real_roots_param(param, roots, nb, pts, precision, maxnbits, step,
                              to_split, info_level);
     if (info_level) {
-      fprintf(stdout, "Elapsed time (real root extraction) = %.2f\n",
+      fprintf(VERBSTREAM, "Elapsed time (real root extraction) = %.2f\n",
               realtime() - st);
-      fflush(stdout);
+      fflush(VERBSTREAM);
     }
   }
   *real_roots_ptr = roots;
@@ -3782,20 +3784,20 @@ int real_msolve_qq(mpz_param_t *mpz_paramp, param_t **nmod_param, int *dim_ptr,
 
   if(info_level && print_gb == 0){
     /* fprintf( */
-    /*     stderr, */
+    /*     ERRSTREAM, */
     /*     "Time for rational param: %13.2f (elapsed) sec / %5.2f sec (cpu)\n\n", */
     /*     rt1 - rt0, ct1 - ct0); */
-    fprintf (stdout,
+    fprintf (VERBSTREAM,
 	     "\n---------------- TIMINGS ----------------\n");
-    fprintf(stdout,
+    fprintf(VERBSTREAM,
 	    "rational param(elapsed) %12.2f sec\n",
 	    rt1-rt0);
-    fprintf(stdout,
+    fprintf(VERBSTREAM,
 	    "rational param(cpu) %16.2f sec\n",
 	    ct1-ct0);
-    fprintf(stdout,
+    fprintf(VERBSTREAM,
 	    "-----------------------------------------\n");
-    fflush(stdout);
+    fflush(VERBSTREAM);
   }
 
   if (get_param > 1) {
@@ -3858,13 +3860,13 @@ void display_arrays_of_real_roots(files_gb *files, int32_t len,
     fprintf(ofile, "];\n");
     fclose(ofile);
   } else {
-    fprintf(stdout, "[");
+    fprintf(VERBSTREAM, "[");
     for (int i = 0; i < len - 1; i++) {
-      display_real_points(stdout, lreal_pts[i], lnbr[i]);
-      fprintf(stdout, ", \n");
+      display_real_points(VERBSTREAM, lreal_pts[i], lnbr[i]);
+      fprintf(VERBSTREAM, ", \n");
     }
-    display_real_points(stdout, lreal_pts[len - 1], lnbr[len - 1]);
-    fprintf(stdout, "];\n");
+    display_real_points(VERBSTREAM, lreal_pts[len - 1], lnbr[len - 1]);
+    fprintf(VERBSTREAM, "];\n");
   }
 }
 
@@ -3879,7 +3881,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
       fprintf(ofile, "[-1]:\n");
       fclose(ofile);
     } else {
-      fprintf(stdout, "[-1]:\n");
+      fprintf(OUTSTREAM, "[-1]:\n");
     }
     return;
   }
@@ -3901,22 +3903,22 @@ void display_output(int b, int dim, int dquot, files_gb *files,
       fprintf(ofile, "]:\n");
       fclose(ofile);
     } else {
-      fprintf(stdout, "[0, ");
+      fprintf(OUTSTREAM, "[0, ");
       if (get_param >= 1 || gens->field_char) {
-        mpz_param_out_str_maple(stdout, gens, dquot, *mpz_paramp, param);
+        mpz_param_out_str_maple(OUTSTREAM, gens, dquot, *mpz_paramp, param);
       }
       if (get_param <= 1 && gens->field_char == 0) {
         if (get_param) {
-          fprintf(stdout, ",");
+          fprintf(OUTSTREAM, ",");
         }
-        display_real_points(stdout, *real_pts_ptr, *nb_real_roots_ptr);
+        display_real_points(OUTSTREAM, *real_pts_ptr, *nb_real_roots_ptr);
       }
-      fprintf(stdout, "]:\n");
+      fprintf(OUTSTREAM, "]:\n");
     }
   }
   if (dim > 0) {
     if (info_level > 0) {
-      fprintf(stdout, "The ideal has positive dimension\n");
+      fprintf(VERBSTREAM, "The ideal has positive dimension\n");
     }
     if (files->out_file != NULL) {
       FILE *ofile2 = fopen(files->out_file, "a+");
@@ -3924,7 +3926,7 @@ void display_output(int b, int dim, int dquot, files_gb *files,
       fprintf(ofile2, "[1, %d, -1, []]:\n", gens->nvars);
       fclose(ofile2);
     } else {
-      fprintf(stdout, "[1, %d, -1, []]:\n", gens->nvars);
+      fprintf(OUTSTREAM, "[1, %d, -1, []]:\n", gens->nvars);
     }
   }
 }
@@ -3939,11 +3941,11 @@ void manage_output(int b, int dim, int dquot, files_gb *files,
                    nb_real_roots_ptr, real_roots_ptr, real_pts_ptr, info_level);
   }
   if (b == -2) {
-    fprintf(stderr, "Characteristic of the field here shouldn't be positive\n");
+    fprintf(ERRSTREAM, "Characteristic of the field here shouldn't be positive\n");
     (*mpz_paramp)->dim = -2;
   }
   if (b == -3) {
-    fprintf(stderr, "Problem when checking meta data\n");
+    fprintf(ERRSTREAM, "Problem when checking meta data\n");
     (*mpz_paramp)->dim = -3;
   }
 }
@@ -4032,26 +4034,26 @@ restart:
                     0 /*truncate_lifting */, info_level);
 
             if (st->homogeneous != 1) {
-                fprintf(stderr,
+                fprintf(ERRSTREAM,
                         "Input system must be homogeneous.\n");
                 exit(1);
             }
 
             st->gfc  = gens->field_char;
             if(info_level){
-                fprintf(stdout,
+                fprintf(VERBSTREAM,
                         "NOTE: Field characteristic is now corrected to %u\n",
                         st->gfc);
             }
             if (!success) {
-                fprintf(stderr,"Bad input data, stopped computation.\n");
+                fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
                 exit(1);
             }
             /* compute a gb for initial generators */
             success = core_sba_schreyer(&bs, &bht, &st);
 
             if (!success) {
-                fprintf(stderr,"Problem with sba, stopped computation.\n");
+                fprintf(ERRSTREAM,"Problem with sba, stopped computation.\n");
                 exit(1);
             }
             int64_t nb  = export_results_from_gba(bld, blen, bexp,
@@ -4063,10 +4065,10 @@ restart:
             st->f4_ctime = ct1 - ct0;
             st->f4_rtime = rt1 - rt0;
 
-            get_and_print_final_statistics(stdout, st, bs);
+            get_and_print_final_statistics(VERBSTREAM, st, bs);
 
             if(nb==0){
-                fprintf(stderr, "Something went wrong during the computation\n");
+                fprintf(ERRSTREAM, "Something went wrong during the computation\n");
                 return -1;
             }
             return 0;
@@ -4092,7 +4094,7 @@ restart:
             int success   = 0;
 
             if(check_ff_bits(gens->field_char) < 32){
-              fprintf(stderr, "Error: not implemented yet (prime field of too low characteristic)\n");
+              fprintf(ERRSTREAM, "Error: not implemented yet (prime field of too low characteristic)\n");
               return 1;
             }
             /*             initialize generators of ideal, note the "gens->ngens-normal_form" which
@@ -4114,7 +4116,7 @@ restart:
                     0 /*truncate_lifting */, info_level);
 
             if (!success) {
-                fprintf(stderr,"Bad input data, stopped computation.\n");
+                fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
                 exit(1);
             }
 
@@ -4140,7 +4142,7 @@ restart:
                 success = core_f4sat(bs, sat, st, &error);
 
                 if (!success) {
-                    fprintf(stderr,"Problem with f4sat, stopped computation.\n");
+                    fprintf(ERRSTREAM,"Problem with f4sat, stopped computation.\n");
                     exit(1);
                 }
                 int64_t nb  = export_results_from_gba(bld, blen, bexp,
@@ -4152,10 +4154,10 @@ restart:
                 st->f4_ctime = ct1 - ct0;
                 st->f4_rtime = rt1 - rt0;
 
-                get_and_print_final_statistics(stdout, st, bs);
+                get_and_print_final_statistics(VERBSTREAM, st, bs);
 
                 if(nb==0){
-                    fprintf(stderr, "Something went wrong during the computation\n");
+                    fprintf(ERRSTREAM, "Something went wrong during the computation\n");
                     return -1;
                 }
                 if (print_gb) {
@@ -4207,23 +4209,23 @@ restart:
 
 	    st->gfc  = gens->field_char;
             if(info_level){
-                fprintf(stdout,
+                fprintf(VERBSTREAM,
                         "NOTE: Field characteristic is now corrected to %u\n",
                         st->gfc);
             }
             if (!success) {
-                fprintf(stderr,"Bad input data, stopped computation.\n");
+                fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
                 exit(1);
             }
 
 	    ct0p = cputime();
 	    rt0p = realtime();
 	    if (info_level) {
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "INIT   TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
+	      fprintf(VERBSTREAM, "INIT   TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
 		      rt0p-rt0, ct0p-ct0);
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
 	    }
             if (is_gb == 1) {
@@ -4238,21 +4240,21 @@ restart:
                 bs = core_gba(bs, st, &err, gens->field_char);
 
                 if (err) {
-                    fprintf(stderr,"Problem with F4, stopped computation.\n");
+                    fprintf(ERRSTREAM,"Problem with F4, stopped computation.\n");
                     exit(1);
                 }
             }
 	    export_results_from_gba(bld, blen, bexp,
 						  bcf, &malloc, &bs, &bht, &st);
-            printf("size of basis: %u\n", bs->lml);
+        fprintf(VERBSTREAM, "size of basis: %u\n", bs->lml);
 	    ct1 = cputime();
 	    rt1 = realtime();
 	    if (info_level) {
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "F4     TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
+	      fprintf(VERBSTREAM, "F4     TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
 		      rt1-rt0p, ct1-ct0p);
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
 	    }
 
@@ -4272,32 +4274,32 @@ restart:
             tbr = core_nf(tbr, st, mul, bs, &err);
 
             if (err) {
-                fprintf(stderr,"Problem with normalform, stopped computation.\n");
+                fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
                 exit(1);
             }
             /* print reduced element in tbr, last one is the input element */
 	    /* printf ("normal form:\n"); */
-            /* print_msolve_polynomials_ff(stdout, 1, tbr->lml, tbr, bht, */
+            /* print_msolve_polynomials_ff(VERBSTREAM, 1, tbr->lml, tbr, bht, */
 	    /* 				st, gens->vnames, 0); */
 	    ct2 = cputime();
 	    rt2 = realtime();
 	    if (info_level) {
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "NF     TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
+	      fprintf(VERBSTREAM, "NF     TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
 		      rt2-rt1, ct2-ct1);
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
 	    }
             /* print all reduced elements in tbr, first  one
              * is the input element */
-            /* print_msolve_polynomials_ff(stdout, 1, tbr->lml, tbr, bht, */
+            /* print_msolve_polynomials_ff(VERBSTREAM, 1, tbr->lml, tbr, bht, */
 	    /* 				st, gens->vnames, 0); */
 	    /* printf("\n"); */
 	    /* list of monomials */
 	    /* size of the list */
 	    long suppsize= tbr->hm[tbr->lmps[1]][LENGTH]; // bs->hm[bs->lmps[1]][LENGTH]
-	    printf("Length of the support of phi: %lu\n",
+	    fprintf(VERBSTREAM, "Length of the support of phi: %lu\n",
 		   suppsize);
 
 	    /* sht and hcm will store the support of the normal form in tbr. */
@@ -4308,7 +4310,7 @@ restart:
 	    /* printf("Starts computation of normal form matrix\n"); */
 	    get_normal_form_matrix(tbr, bht, 1,
 				   st, &sht, &hcm, &mat);
-	    printf("Length of union of support of all normal forms: %u\n",
+	    fprintf(VERBSTREAM, "Length of union of support of all normal forms: %u\n",
 		   mat->nc);
 
 	    /* printf("\nUnion of support, sorted by decreasing monomial order:\n"); */
@@ -4350,7 +4352,7 @@ restart:
 	    /*   } */
 	    /*   printf("\n"); */
 	    /* } */
-	    printf("Subspace of quotient algebra has dimension: %ld\n",dquot);
+	    fprintf(VERBSTREAM, "Subspace of quotient algebra has dimension: %ld\n",dquot);
 	    uint32_t * leftvector = calloc(dquot,sizeof (uint32_t));
 	    uint32_t ** leftvectorsparam = malloc(2*(gens->nvars-1)*sizeof (uint32_t *));
 	    for (long i = 0; i < 2*(gens->nvars-1); i++) {
@@ -4382,11 +4384,11 @@ restart:
 	    ct3 = cputime();
 	    rt3 = realtime();
 	    if (info_level) {
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "MATRIX TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
+	      fprintf(VERBSTREAM, "MATRIX TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
 		      rt3-rt2, ct3-ct2);
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
 	    }
 	    nvars_t *linvars = calloc(gens->nvars, sizeof(nvars_t));
@@ -4399,32 +4401,32 @@ restart:
 	    ct4 = cputime();
 	    rt4 = realtime();
 	    if (info_level) {
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "FGLM  TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
+	      fprintf(VERBSTREAM, "FGLM  TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
 		      rt4-rt3, ct4-ct3);
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
 	    }
-	    display_fglm_param(stdout, param);
+	    display_fglm_param(VERBSTREAM, param);
 	    if (info_level) {
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "TOTAL  TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
+	      fprintf(VERBSTREAM, "TOTAL  TIMING %13.2f sec (REAL) / %5.2f sec (CPU)\n",
 		      rt4-rt0, ct4-ct0);
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
-	      fprintf(stdout, "INIT   PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
+	      fprintf(VERBSTREAM, "INIT   PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
 		      100*(rt0p-rt0)/(rt4-rt0), 100*(ct0p-ct0)/(ct4-ct0));
-	      fprintf(stdout, "F4     PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
+	      fprintf(VERBSTREAM, "F4     PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
 		      100*(rt1-rt0p)/(rt4-rt0), 100*(ct1-ct0p)/(ct4-ct0));
-	      fprintf(stdout, "NF     PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
+	      fprintf(VERBSTREAM, "NF     PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
 		      100*(rt2-rt1)/(rt4-rt0), 100*(ct2-ct1)/(ct4-ct0));
-	      fprintf(stdout, "MATRIX PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
+	      fprintf(VERBSTREAM, "MATRIX PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
 		      100*(rt3-rt2)/(rt4-rt0), 100*(ct3-ct2)/(ct4-ct0));
-	      fprintf(stdout, "FGLM   PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
+	      fprintf(VERBSTREAM, "FGLM   PERCTG %13.2f%% (REAL) / %5.2f%% (CPU)\n",
 		      100*(rt4-rt3)/(rt4-rt0), 100*(ct4-ct3)/(ct4-ct0));
-	      fprintf(stdout, "-------------------------------------------------\
+	      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
 	    }
 	    free(param);
@@ -4470,8 +4472,8 @@ restart:
 	  long dquot = -1;
 
       if(elim_block_len > 0 && print_gb == 0){
-          fprintf(stderr, "Warning: elim order not available for rational parametrizations\n");
-          fprintf(stderr, "Computing Groebner basis\n");
+          fprintf(ERRSTREAM, "Warning: elim order not available for rational parametrizations\n");
+          fprintf(ERRSTREAM, "Computing Groebner basis\n");
           print_gb=2;
       }
 	  b = real_msolve_qq(mpz_paramp,
@@ -4520,13 +4522,13 @@ restart:
                 }
               }
             }
-            fprintf(stderr, "\n=====> Computation failed <=====\n");
-            fprintf(stderr, "Try to add a random linear form with ");
-            fprintf(stderr, "a new variable\n");
-            fprintf(stderr, "(smallest w.r.t. DRL) to the input system. ");
-            fprintf(stderr, "This will\n");
-            fprintf(stderr, "be done automatically if you run msolve with option\n");
-            fprintf(stderr, "\"-c2\" which is the default.\n");
+            fprintf(ERRSTREAM, "\n=====> Computation failed <=====\n");
+            fprintf(ERRSTREAM, "Try to add a random linear form with ");
+            fprintf(ERRSTREAM, "a new variable\n");
+            fprintf(ERRSTREAM, "(smallest w.r.t. DRL) to the input system. ");
+            fprintf(ERRSTREAM, "This will\n");
+            fprintf(ERRSTREAM, "be done automatically if you run msolve with option\n");
+            fprintf(ERRSTREAM, "\"-c2\" which is the default.\n");
           }
           if(b == 2){
             free(bld);
@@ -4548,13 +4550,13 @@ restart:
 		goto restart;
 	      }
 	    }
-	    fprintf(stderr, "\n=====> Computation failed <=====\n");
-            fprintf(stderr, "Try to add a random linear form with ");
-            fprintf(stderr, "a new variable\n");
-            fprintf(stderr, "(smallest w.r.t. DRL) to the input system. ");
-            fprintf(stderr, "This will\n");
-            fprintf(stderr, "be done automatically if you run msolve with option\n");
-            fprintf(stderr, "\"-c2\" which is the default.\n");
+	    fprintf(ERRSTREAM, "\n=====> Computation failed <=====\n");
+        fprintf(ERRSTREAM, "Try to add a random linear form with ");
+        fprintf(ERRSTREAM, "a new variable\n");
+        fprintf(ERRSTREAM, "(smallest w.r.t. DRL) to the input system. ");
+        fprintf(ERRSTREAM, "This will\n");
+        fprintf(ERRSTREAM, "be done automatically if you run msolve with option\n");
+        fprintf(ERRSTREAM, "\"-c2\" which is the default.\n");
 	  }
         }
 	else {
@@ -4593,7 +4595,7 @@ restart:
 
             st->gfc  = gens->field_char;
             if (!success) {
-                fprintf(stderr,"Bad input data, stopped computation.\n");
+                fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
                 exit(1);
             }
 
@@ -4609,7 +4611,7 @@ restart:
                 bs = core_gba(bs, st, &err, gens->field_char);
 
                 if (err) {
-                    printf("Problem with F4, stopped computation.\n");
+                    fprintf(ERRSTREAM, "Problem with F4, stopped computation.\n");
                     exit(1);
                 }
             }
@@ -4632,7 +4634,7 @@ restart:
             tbr = core_nf(tbr, st, mul, bs, &err);
 
             if (err) {
-                fprintf(stderr,"Problem with normalform, stopped computation.\n");
+                fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
                 exit(1);
             }
             /* print all reduced elements in tbr, first normal_form ones
@@ -4645,54 +4647,54 @@ restart:
                 hi_t *hcm   = (hi_t *)malloc(sizeof(hi_t));
                 mat_t *mat  = (mat_t *)calloc(1, sizeof(mat_t));
 
-                printf("\nStarts computation of normal form matrix\n");
+                fprintf(VERBSTREAM, "\nStarts computation of normal form matrix\n");
                 get_normal_form_matrix(tbr, tbr->ht, normal_form,
                         st, &sht, &hcm, &mat);
 
-                printf("\n\nLength of union of support of all normal forms: %u\n",
+                fprintf(VERBSTREAM, "\n\nLength of union of support of all normal forms: %u\n",
                         mat->nc);
 
-                printf("\nUnion of support, sorted by decreasing monomial order:\n");
+                fprintf(VERBSTREAM, "\nUnion of support, sorted by decreasing monomial order:\n");
                 for (len_t k = 0; k < mat->nc; ++k) {
                     for (len_t l = 1; l <= sht->nv; ++l) {
-                        printf("%2u ", sht->ev[hcm[k]][l]);
+                        fprintf(VERBSTREAM, "%2u ", sht->ev[hcm[k]][l]);
                     }
-                    printf("\n");
+                    fprintf(VERBSTREAM, "\n");
                 }
 
                 /* sparse represented matrix of normal forms, note that the column entries
                  * of the rows are not sorted, but you can do so using any sort algorithm */
-                printf("\nMatrix of normal forms (sparse format, note that entries are\n");
-                printf("NOT completely sorted by column index):\n");
+                fprintf(VERBSTREAM, "\nMatrix of normal forms (sparse format, note that entries are\n");
+                fprintf(VERBSTREAM, "NOT completely sorted by column index):\n");
                 int64_t nterms  = 0;
                 for (len_t k = 0; k < mat->nr; ++k) {
-                    printf("row %u | ", k);
+                    fprintf(VERBSTREAM, "row %u | ", k);
                     for (len_t l = 0; l < mat->tr[k][LENGTH]; ++l) {
-                        printf("%u at %u, ",
+                        fprintf(VERBSTREAM, "%u at %u, ",
                                 tbr->cf_32[mat->tr[k][COEFFS]][l],
                                 mat->tr[k][l+OFFSET]);
                     }
-                    printf("\n");
+                    fprintf(VERBSTREAM, "\n");
                     nterms  +=  mat->tr[k][LENGTH];
                 }
                 nterms  *=  100; /* for percentage */
                 double density = (double)nterms / (double)mat->nr / (double)mat->nc;
-                printf("\nMatrix of normal forms (dense format)\n");
+                fprintf(VERBSTREAM, "\nMatrix of normal forms (dense format)\n");
                 cf32_t *dr  = (cf32_t *)malloc(
                         (unsigned long)mat->nc * sizeof(cf32_t));
                 for (len_t k = 0; k < mat->nr; ++k) {
                     memset(dr, 0, (unsigned long)mat->nc * sizeof(cf32_t));
-                    printf("row %u | ", k);
+                    fprintf(VERBSTREAM, "row %u | ", k);
                     for (len_t l = 0; l < mat->tr[k][LENGTH]; ++l) {
                         dr[mat->tr[k][l+OFFSET]]  =
                             tbr->cf_32[mat->tr[k][COEFFS]][l];
                     }
                     for (len_t l = 0; l < mat->nc; ++l) {
-                        printf("%u, ", dr[l]);
+                        fprintf(VERBSTREAM, "%u, ", dr[l]);
                     }
-                    printf("\n");
+                    fprintf(VERBSTREAM, "\n");
                 }
-                printf("density of matrix: %.2f%%\n", density);
+                fprintf(VERBSTREAM, "density of matrix: %.2f%%\n", density);
                 for (len_t k = 0; k < mat->nr; ++k) {
                     free(mat->tr[k]);
                 }
@@ -4741,7 +4743,7 @@ restart:
 
             /* all data is corrupt */
             if (res == -1) {
-                fprintf(stderr, "Invalid input generators, msolve now terminates.\n");
+                fprintf(ERRSTREAM, "Invalid input generators, msolve now terminates.\n");
                 free(invalid_gens);
                 return -3;
             }
@@ -4774,7 +4776,7 @@ restart:
             import_input_data(bs_qq, st, 0, st->ngens_input, gens->lens, gens->exps,
                     (void *)gens->mpz_cfs, invalid_gens);
 
-            print_initial_statistics(stdout, st);
+            print_initial_statistics(VERBSTREAM, st);
 
             /* for faster divisibility checks, needs to be done after we have
              * read some input data for applying heuristics */
@@ -4837,10 +4839,10 @@ restart:
             st->f4_rtime = rt1 - rt0;
 
             if (st->info_level > 1) {
-                print_final_statistics(stdout, st);
+                print_final_statistics(VERBSTREAM, st);
             }
             if(info_level){
-                fprintf(stdout, "\nStarts trace based multi-modular computations\n");
+                fprintf(VERBSTREAM, "\nStarts trace based multi-modular computations\n");
             }
 
             int i;
@@ -4884,7 +4886,7 @@ restart:
                             lp->p[i]);
 
                     stf4 = realtime()-ca0;
-                    printf("F4 trace timing %13.2f\n", stf4);
+                    fprintf(VERBSTREAM, "F4 trace timing %13.2f\n", stf4);
                     /* printf("bs[%u]->lml = %u\n", i, bs[i]->lml); */
                 }
             /* } */
@@ -4920,7 +4922,7 @@ restart:
 
             /* all data is corrupt */
             if (res == -1) {
-                fprintf(stderr, "Invalid input generators, msolve now terminates.\n");
+                fprintf(ERRSTREAM, "Invalid input generators, msolve now terminates.\n");
                 free(invalid_gens);
                 return -3;
             }
@@ -4956,7 +4958,7 @@ restart:
             free(invalid_gens);
             invalid_gens    =   NULL;
 
-            print_initial_statistics(stdout, st);
+            print_initial_statistics(VERBSTREAM, st);
 
             /* for faster divisibility checks, needs to be done after we have
              * read some input data for applying heuristics */
@@ -5007,7 +5009,7 @@ restart:
             }
 
             if (info_level){
-                fprintf(stdout,"LEARNING PHASE -- PART 1\n");
+                fprintf(VERBSTREAM,"LEARNING PHASE -- PART 1\n");
             }
             f4sat_trace_learning_phase_1(
                     trace,
@@ -5027,10 +5029,10 @@ restart:
             st->f4_ctime = ct1 - ct0;
             st->f4_rtime = rt1 - rt0;
 
-            get_and_print_final_statistics(stdout, st, bs_qq);
+            get_and_print_final_statistics(VERBSTREAM, st, bs_qq);
 
             if(info_level){
-                fprintf(stdout, "\nStarts trace based multi-modular computations\n");
+                fprintf(VERBSTREAM, "\nStarts trace based multi-modular computations\n");
             }
 
             prime = next_prime(1<<30);
@@ -5038,7 +5040,7 @@ restart:
             lp->p[0]  = prime;
 
             if (info_level){
-                fprintf(stdout,"LEARNING PHASE -- PART 2\n");
+                fprintf(VERBSTREAM,"LEARNING PHASE -- PART 2\n");
             }
             f4sat_trace_learning_phase_2(
                     trace,
@@ -5058,10 +5060,10 @@ restart:
             st->f4_ctime = ct1 - ct0;
             st->f4_rtime = rt1 - rt0;
 
-            get_and_print_final_statistics(stdout, st, bs_qq);
+            get_and_print_final_statistics(VERBSTREAM, st, bs_qq);
 
             if(info_level){
-                fprintf(stdout, "\nStarts trace based multi-modular computations\n");
+                fprintf(VERBSTREAM, "\nStarts trace based multi-modular computations\n");
             }
 
             int i;
@@ -5107,7 +5109,7 @@ restart:
 
                     stf4 = realtime()-ca0;
                     if (info_level) {
-                        printf("F4 trace timing %13.2f\n", stf4);
+                        fprintf(VERBSTREAM, "F4 trace timing %13.2f\n", stf4);
                     }
                     /* printf("bs[%u]->lml = %u\n", i, bs[i]->lml); */
                 }
@@ -5119,8 +5121,8 @@ restart:
             long dquot = -1;
 
             if(elim_block_len && print_gb == 0){
-                fprintf(stderr, "Warning: elim order not available for rational parametrizations\n");
-                fprintf(stderr, "Computing Groebner basis\n");
+                fprintf(ERRSTREAM, "Warning: elim order not available for rational parametrizations\n");
+                fprintf(ERRSTREAM, "Computing Groebner basis\n");
                 print_gb=2;
             }
 
@@ -5197,17 +5199,17 @@ restart:
                         }
                     }
                 }
-                fprintf(stderr, "\n=====> Computation failed <=====\n");
-                fprintf(stderr, "Try to add a random linear form with ");
-                fprintf(stderr, "a new variable\n");
-                fprintf(stderr, "(smallest w.r.t. DRL) to the input system. ");
-                fprintf(stderr, "This will\n");
-                fprintf(stderr, "be done automatically if you run msolve with option\n");
-                fprintf(stderr, "\"-c2\" which is the default.\n");
+                fprintf(ERRSTREAM, "\n=====> Computation failed <=====\n");
+                fprintf(ERRSTREAM, "Try to add a random linear form with ");
+                fprintf(ERRSTREAM, "a new variable\n");
+                fprintf(ERRSTREAM, "(smallest w.r.t. DRL) to the input system. ");
+                fprintf(ERRSTREAM, "This will\n");
+                fprintf(ERRSTREAM, "be done automatically if you run msolve with option\n");
+                fprintf(ERRSTREAM, "\"-c2\" which is the default.\n");
                 (*mpz_paramp)->dim  = -1;
             }
             if(b == -4){
-                fprintf(stderr, "Bad prime chosen initially\n");
+                fprintf(ERRSTREAM, "Bad prime chosen initially\n");
                 free(bld);
                 bld = NULL;
                 free(blen);
@@ -5243,13 +5245,13 @@ restart:
                     goto restart;
                   }
                 }
-                fprintf(stderr, "\n=====> Computation failed <=====\n");
-                fprintf(stderr, "Try to add a random linear form with ");
-                fprintf(stderr, "a new variable\n");
-                fprintf(stderr, "(smallest w.r.t. DRL) to the input system. ");
-                fprintf(stderr, "This will\n");
-                fprintf(stderr, "be done automatically if you run msolve with option\n");
-                fprintf(stderr, "\"-c2\" which is the default.\n");
+                fprintf(ERRSTREAM, "\n=====> Computation failed <=====\n");
+                fprintf(ERRSTREAM, "Try to add a random linear form with ");
+                fprintf(ERRSTREAM, "a new variable\n");
+                fprintf(ERRSTREAM, "(smallest w.r.t. DRL) to the input system. ");
+                fprintf(ERRSTREAM, "This will\n");
+                fprintf(ERRSTREAM, "be done automatically if you run msolve with option\n");
+                fprintf(ERRSTREAM, "\"-c2\" which is the default.\n");
             }
 	    if(b == 3){
                 free(bld);
@@ -5318,8 +5320,8 @@ restart:
                or of a 0-dimensional ideal of wrong degree,
                restart with the same linear form */
             if (info_level > 0) {
-                fprintf (stdout, "\nWrong dimension or degree\n");
-                fprintf (stdout, "Restarting with the same linear form\n");
+                fprintf (VERBSTREAM, "\nWrong dimension or degree\n");
+                fprintf (VERBSTREAM, "Restarting with the same linear form\n");
             }
             goto restart;
         }
@@ -5604,11 +5606,11 @@ void msolve_julia(
     if (info_level > 0) {
         double st1 = cputime();
         double rt1 = realtime();
-        fprintf(stdout, "\n-------------------------------------------------\
+        fprintf(VERBSTREAM, "\n-------------------------------------------------\
 -----------------------------------\n");
-        fprintf(stdout, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
+        fprintf(VERBSTREAM, "msolve overall time  %13.2f sec (elapsed) / %5.2f sec (cpu)\n",
                 rt1-rt0, st1-st0);
-        fprintf(stdout, "-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 -----------------------------------\n");
     }
 }

--- a/src/msolve/streams.h
+++ b/src/msolve/streams.h
@@ -1,0 +1,28 @@
+/* This file is part of msolve.
+ *
+ * msolve is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * msolve is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with msolve.  If not, see <https://www.gnu.org/licenses/>
+ *
+ * Authors:
+ * Jérémy Berthomieu
+ * Christian Eder
+ * Mohab Safey El Din */
+
+#ifndef STREAMS_H
+#define STREAMS_H
+
+#define OUTSTREAM stdout
+#define VERBSTREAM stderr
+#define ERRSTREAM stderr
+
+#endif

--- a/src/neogb/convert.c
+++ b/src/neogb/convert.c
@@ -198,8 +198,8 @@ static void convert_hashes_to_columns_sat(
     st->convert_ctime +=  ct1 - ct0;
     st->convert_rtime +=  rt1 - rt0;
     if (st->info_level > 1) {
-        printf(" %7d x %-7d %8.2f%%", mat->nr + sat->ld, mat->nc, density);
-        fflush(stdout);
+        fprintf(VERBSTREAM, " %7d x %-7d %8.2f%%", mat->nr + sat->ld, mat->nc, density);
+        fflush(VERBSTREAM);
     }
     st->hcm = hcm;
 }
@@ -289,8 +289,8 @@ static void sba_convert_hashes_to_columns(
     st->convert_ctime +=  ct1 - ct0;
     st->convert_rtime +=  rt1 - rt0;
     if (st->info_level > 1) {
-        printf("%4d    %7d x %-7d %8.2f%%", smat->cd, smat->cld, smat->nc, density);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%4d    %7d x %-7d %8.2f%%", smat->cd, smat->cld, smat->nc, density);
+        fflush(VERBSTREAM);
     }
     *hcmp = hcm;
 }
@@ -326,8 +326,8 @@ static void convert_hashes_to_columns(
      * exactly one column of the matrix */
     hcm = realloc(hcm, (uint64_t)(esld-1) * sizeof(hi_t));
     if (hcm == NULL) {
-        fprintf(stderr, "Allocating memory for hash-column lookup table failed,\n");
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Allocating memory for hash-column lookup table failed,\n");
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     for (k = 0, j = 0, i = 1; i < esld; ++i) {
         hi  = hds[i].idx;
@@ -422,8 +422,8 @@ static void convert_hashes_to_columns(
     st->convert_ctime +=  ct1 - ct0;
     st->convert_rtime +=  rt1 - rt0;
     if (st->info_level > 1) {
-        printf(" %7d x %-7d %8.2f%%", mat->nr, mat->nc, density);
-        fflush(stdout);
+        fprintf(VERBSTREAM, " %7d x %-7d %8.2f%%", mat->nr, mat->nc, density);
+        fflush(VERBSTREAM);
     }
     if ((int64_t)mat->nr * mat->nc > st->mat_max_nrows * st->mat_max_ncols) {
         st->mat_max_nrows = mat->nr;

--- a/src/neogb/engine.c
+++ b/src/neogb/engine.c
@@ -20,6 +20,7 @@
 
 
 #include "engine.h"
+#include "../msolve/streams.h"
 
 int initialize_gba_input_data(
         bs_t **bsp,
@@ -85,7 +86,7 @@ int initialize_gba_input_data(
 
     import_input_data(bs, st, 0, st->ngens_input, lens, exps, cfs, invalid_gens);
 
-    print_initial_statistics(stdout, st);
+    print_initial_statistics(VERBSTREAM, st);
 
     /* for faster divisibility checks, needs to be done after we have
      * read some input data for applying heuristics */

--- a/src/neogb/f4.c
+++ b/src/neogb/f4.c
@@ -20,7 +20,7 @@
 
 
 #include "f4.h"
-
+#include "../msolve/streams.h"
 
 static void final_remove_redundant_elements(
         bs_t *bs,
@@ -177,8 +177,8 @@ static void intermediate_reduce_basis(
 
     /* generate hash <-> column mapping */
     if (st->info_level > 1) {
-        printf("reduce intermediate basis ");
-        fflush(stdout);
+        fprintf(VERBSTREAM, "reduce intermediate basis ");
+        fflush(VERBSTREAM);
     }
     convert_hashes_to_columns(mat, st, sht);
     mat->nc = mat->ncl + mat->ncr;
@@ -241,11 +241,11 @@ static void intermediate_reduce_basis(
     st->reduce_gb_ctime = ct1 - ct0;
     st->reduce_gb_rtime = rt1 - rt0;
     if (st->info_level > 1) {
-        printf("%13.2f sec\n", rt1-rt0);
+        fprintf(VERBSTREAM, "%13.2f sec\n", rt1-rt0);
     }
 
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
 }
@@ -291,8 +291,8 @@ static void reduce_basis(
 
     /* generate hash <-> column mapping */
     if (md->info_level > 1) {
-        printf("reduce final basis ");
-        fflush(stdout);
+        fprintf(VERBSTREAM, "reduce final basis ");
+        fflush(VERBSTREAM);
     }
     convert_hashes_to_columns(mat, md, sht);
     mat->nc = mat->ncl + mat->ncr;
@@ -335,8 +335,8 @@ start:
 
     md->in_final_reduction_step = 0;
 
-    print_round_timings(stdout, md, rt, ct);
-    print_round_information_footer(stdout, md);
+    print_round_timings(VERBSTREAM, md, rt, ct);
+    print_round_information_footer(VERBSTREAM, md);
 }
 
 static int32_t initialize_f4(
@@ -433,7 +433,7 @@ static int32_t compute_new_elements(
     if (md->trace_level == APPLY_TRACER) {
         if (mat->np != md->tr->td[md->trace_rd].nlm) {
             if (md->info_level > 0) {
-                fprintf(stderr, "Wrong number of new elements, bad prime.");
+                fprintf(ERRSTREAM, "Wrong number of new elements, bad prime.");
             }
             *errp = 1;
             return 1;
@@ -454,7 +454,7 @@ static int32_t compute_new_elements(
         for (i = 0; i < md->np; ++i) {
             if (bs->hm[bs->ld+i][OFFSET] != md->tr->td[md->trace_rd].nlms[i]) {
                 if (md->info_level > 0) {
-                fprintf(stderr, "Wrong leading term for new element %u/%u, bad prime.",
+                fprintf(ERRSTREAM, "Wrong leading term for new element %u/%u, bad prime.",
                         i, mat->np);
                 }
                 *errp = 2;
@@ -602,8 +602,8 @@ static void reduce_final_basis(
 
         /* generate hash <-> column mapping */
         if (md->info_level > 1) {
-            printf("reduce final basis ");
-            fflush(stdout);
+            fprintf(VERBSTREAM, "reduce final basis ");
+            fflush(VERBSTREAM);
         }
         convert_hashes_to_columns(mat, md, sht);
         mat->nc = mat->ncl + mat->ncr;
@@ -629,8 +629,8 @@ static void reduce_final_basis(
         md->in_final_reduction_step = 0;
 
         /* timings */
-        print_round_timings(stdout, md, rt, ct);
-        print_round_information_footer(stdout, md);
+        print_round_timings(VERBSTREAM, md, rt, ct);
+        print_round_information_footer(VERBSTREAM, md);
     }
 }
 
@@ -691,7 +691,7 @@ bs_t *core_f4(
 
     /* let's start the f4 rounds, we are done when no more spairs
        are left in the pairset or if we found a constant in the basis. */
-    print_round_information_header(stdout, md);
+    print_round_information_header(VERBSTREAM, md);
 
     /* reset error */
     *errp = 0;
@@ -710,12 +710,12 @@ bs_t *core_f4(
             done = update(bs, md);
         }
 
-        print_round_timings(stdout, md, rrt, crt);
+        print_round_timings(VERBSTREAM, md, rrt, crt);
     }
     if (*errp > 0) {
         free_basis_and_only_local_hash_table_data(&bs);
     } else {
-        print_round_information_footer(stdout, md);
+        print_round_information_footer(VERBSTREAM, md);
 
         /* remove possible redudant elements */
         process_redundant_elements(bs, md);
@@ -726,7 +726,7 @@ bs_t *core_f4(
         md->f4_rtime = realtime() - rt;
         md->f4_ctime = cputime() - ct;
 
-        get_and_print_final_statistics(stdout, md, bs);
+        get_and_print_final_statistics(VERBSTREAM, md, bs);
 
         finalize_f4(gmd, gbs, &bs, &md, &mat, *errp);
     }
@@ -817,7 +817,7 @@ int64_t export_f4(
         return 1;
     }
     if (success == 0) {
-        fprintf(stderr,"Bad input data, stopped computation.\n");
+        fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
         exit(1);
     }
 
@@ -825,7 +825,7 @@ int64_t export_f4(
     bs = core_f4(bs, md, &err, field_char);
 
     if (err) {
-        fprintf(stderr,"Problem with F4, stopped computation.\n");
+        fprintf(ERRSTREAM,"Problem with F4, stopped computation.\n");
         exit(1);
     }
 
@@ -838,7 +838,7 @@ int64_t export_f4(
     md->f4_ctime = ct1 - ct0;
     md->f4_rtime = rt1 - rt0;
 
-    get_and_print_final_statistics(stderr, md, bs);
+    get_and_print_final_statistics(ERRSTREAM, md, bs);
 
     /* free and clean up */
     free_shared_hash_data(bht);

--- a/src/neogb/f4sat.c
+++ b/src/neogb/f4sat.c
@@ -20,6 +20,7 @@
 
 
 #include "f4sat.h"
+#include "../msolve/streams.h"
 
 static inline void free_kernel_coefficients(
         bs_t *kernel
@@ -95,7 +96,7 @@ static int is_already_saturated(
         )
 {
     if(st->info_level){
-      printf("testing if system is already saturated: ");
+      fprintf(VERBSTREAM, "testing if system is already saturated: ");
     }
     double rrt0, rrt1;
     rrt0  = realtime();
@@ -205,15 +206,15 @@ static int is_already_saturated(
 
     if (st->info_level){
       if (is_constant == 1) {
-        printf("yes.");
+        fprintf(VERBSTREAM, "yes.");
       } else {
-        printf("no.");
+        fprintf(VERBSTREAM, "no.");
       }
     }
 
     rrt1 = realtime();
     if (st->info_level > 1) {
-        printf("%40.2f sec\n", rrt1-rrt0);
+        fprintf(VERBSTREAM, "%40.2f sec\n", rrt1-rrt0);
     }
 
     return is_constant;
@@ -561,7 +562,7 @@ int core_f4sat(
 
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
-    print_round_information_header(stdout, st);
+    print_round_information_header(VERBSTREAM, st);
     round = 1;
 end_sat_step:
     for (; ps->ld > 0; ++round) {
@@ -600,12 +601,12 @@ end_sat_step:
         update_basis_f4(ps, bs, bht, st, mat->np);
 
         if (bs->constant  == 1) {
-            printf("basis is constant\n");
+            fprintf(VERBSTREAM, "basis is constant\n");
             ps->ld  = 0;
             break;
         }
         clean_hash_table(sht);
-        print_round_timings(stdout, st, rrt, crt);
+        print_round_timings(VERBSTREAM, st, rrt, crt);
 
         /* saturation step starts here */
         if ((bs->mltdeg >= sat->hm[0][DEG] && sat_test != 0) || ps->ld == 0) {
@@ -643,7 +644,7 @@ end_sat_step:
                 if (mat->nru > 0) {
                     if (st->info_level > 1) {
                         /* printf("kernel computation "); */
-                        printf("%3u  compute kernel", sat_deg);
+                        fprintf(VERBSTREAM, "%3u  compute kernel", sat_deg);
                     }
                     convert_hashes_to_columns_sat(mat, sat, st, sht);
                     convert_multipliers_to_columns(&hcmm, sat, st, bht);
@@ -652,13 +653,13 @@ end_sat_step:
                     compute_kernel_sat_ff_32(sat, mat, kernel, bs, st);
 
                     if (st->info_level > 1) {
-                        printf("%56d new kernel elements", kernel->ld);
-                        fflush(stdout);
+                        fprintf(VERBSTREAM, "%56d new kernel elements", kernel->ld);
+                        fflush(VERBSTREAM);
                     }
 
                     if (kernel->ld > 0) {
                         if (st->info_level > 1) {
-                            printf("\n                                               ");
+                            fprintf(VERBSTREAM, "\n                                               ");
                         }
                         clear_matrix(mat);
                         /* interreduce kernel */
@@ -682,7 +683,7 @@ end_sat_step:
                         update_basis_f4(ps, bs, bht, st, mat->np);
                         kernel->ld  = 0;
                         if (st->info_level > 1) {
-                            printf("   ");
+                            fprintf(VERBSTREAM, "   ");
                         }
                     }
                     /* all rows in mat are now polynomials in the basis,
@@ -718,7 +719,7 @@ end_sat_step:
                 }
                 clean_hash_table(sht);
 
-                print_sat_round_timings(stdout, st, rrt, crt);
+                print_sat_round_timings(VERBSTREAM, st, rrt, crt);
                 if (bld != bs->ld) {
                     next_deg  = ii;
                     goto end_sat_step;
@@ -727,7 +728,7 @@ end_sat_step:
             next_deg  = sat_deg;
         }
     }
-    print_round_information_footer(stdout, st);
+    print_round_information_footer(VERBSTREAM, st);
     /* remove possible redudant elements */
     final_remove_redundant_elements(bs, st, bht);
 
@@ -740,7 +741,7 @@ end_sat_step:
     st->f4_rtime = realtime() - rt;
     st->f4_ctime = cputime() - ct;
 
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 /*     printf("basis has  %u elements.\n", bs->lml);
  *
  *     for (i = 0; i < bs->lml; ++i) {

--- a/src/neogb/hash.c
+++ b/src/neogb/hash.c
@@ -20,6 +20,7 @@
 
 
 #include "hash.h"
+#include "../msolve/streams.h"
 
 /* we have three different hash tables:
  * 1. one hash table for elements in the basis (bht)
@@ -108,16 +109,16 @@ ht_t *initialize_basis_hash_table(
     ht->hd  = (hd_t *)calloc(ht->esz, sizeof(hd_t));
     ht->ev  = (exp_t **)malloc(ht->esz * sizeof(exp_t *));
     if (ht->ev == NULL) {
-        fprintf(stderr, "Computation needs too much memory on this machine,\n");
-        fprintf(stderr, "could not initialize exponent vector for hash table,\n");
-        fprintf(stderr, "esz = %lu, segmentation fault will follow.\n", (unsigned long)ht->esz);
+        fprintf(ERRSTREAM, "Computation needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "could not initialize exponent vector for hash table,\n");
+        fprintf(ERRSTREAM, "esz = %lu, segmentation fault will follow.\n", (unsigned long)ht->esz);
     }
     exp_t *tmp  = (exp_t *)malloc(
             (unsigned long)ht->evl * ht->esz * sizeof(exp_t));
     if (tmp == NULL) {
-        fprintf(stderr, "Exponent storage needs too much memory on this machine,\n");
-        fprintf(stderr, "initialization failed, esz = %lu,\n", (unsigned long)ht->esz);
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Exponent storage needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "initialization failed, esz = %lu,\n", (unsigned long)ht->esz);
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     const hl_t esz  = ht->esz;
     for (j = 0; j < esz; ++j) {
@@ -157,16 +158,16 @@ ht_t *copy_hash_table(
     memcpy(ht->hd, bht->hd, (unsigned long)ht->esz * sizeof(hd_t));
     ht->ev  = (exp_t **)malloc(ht->esz * sizeof(exp_t *));
     if (ht->ev == NULL) {
-        fprintf(stderr, "Computation needs too much memory on this machine,\n");
-        fprintf(stderr, "could not initialize exponent vector for hash table,\n");
-        fprintf(stderr, "esz = %lu, segmentation fault will follow.\n", (unsigned long)ht->esz);
+        fprintf(ERRSTREAM, "Computation needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "could not initialize exponent vector for hash table,\n");
+        fprintf(ERRSTREAM, "esz = %lu, segmentation fault will follow.\n", (unsigned long)ht->esz);
     }
     exp_t *tmp  = (exp_t *)malloc(
             (unsigned long)ht->evl * ht->esz * sizeof(exp_t));
     if (tmp == NULL) {
-        fprintf(stderr, "Exponent storage needs too much memory on this machine,\n");
-        fprintf(stderr, "initialization failed, esz = %lu,\n", (unsigned long)ht->esz);
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Exponent storage needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "initialization failed, esz = %lu,\n", (unsigned long)ht->esz);
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     memcpy(tmp, bht->ev[0], (unsigned long)ht->evl * ht->esz * sizeof(exp_t));
     ht->eld = bht->eld;
@@ -185,7 +186,7 @@ ht_t *initialize_secondary_hash_table(
 {
     hl_t j;
 
-    ht_t *ht  = (ht_t *)malloc(sizeof(ht_t)); 
+    ht_t *ht  = (ht_t *)malloc(sizeof(ht_t));
     ht->nv    = bht->nv;
     ht->evl   = bht->evl;
     ht->ebl   = bht->ebl;
@@ -209,16 +210,16 @@ ht_t *initialize_secondary_hash_table(
     ht->hd  = (hd_t *)calloc(ht->esz, sizeof(hd_t));
     ht->ev  = (exp_t **)malloc(ht->esz * sizeof(exp_t *));
     if (ht->ev == NULL) {
-        fprintf(stderr, "Computation needs too much memory on this machine,\n");
-        fprintf(stderr, "could not initialize exponent vector for hash table,\n");
-        fprintf(stderr, "esz = %lu, segmentation fault will follow.\n", (unsigned long)ht->esz);
+        fprintf(ERRSTREAM, "Computation needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "could not initialize exponent vector for hash table,\n");
+        fprintf(ERRSTREAM, "esz = %lu, segmentation fault will follow.\n", (unsigned long)ht->esz);
     }
     exp_t *tmp  = (exp_t *)malloc(
             (unsigned long)ht->evl * ht->esz * sizeof(exp_t));
     if (tmp == NULL) {
-        fprintf(stderr, "Exponent storage needs too much memory on this machine,\n");
-        fprintf(stderr, "initialization failed, esz = %lu,\n", (unsigned long)ht->esz);
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Exponent storage needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "initialization failed, esz = %lu,\n", (unsigned long)ht->esz);
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     const hl_t esz  = ht->esz;
     for (j = 0; j < esz; ++j) {
@@ -327,16 +328,16 @@ static void enlarge_hash_table(
     memset(ht->hd+eld, 0, (esz-eld) * sizeof(hd_t));
     ht->ev    = realloc(ht->ev, esz * sizeof(exp_t *));
     if (ht->ev == NULL) {
-        fprintf(stderr, "Enlarging hash table failed for esz = %lu,\n", (unsigned long)esz);
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Enlarging hash table failed for esz = %lu,\n", (unsigned long)esz);
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     /* note: memory is allocated as one big block, so reallocating
      *       memory from ev[0] is enough    */
     ht->ev[0] = realloc(ht->ev[0],
             esz * (unsigned long)ht->evl * sizeof(exp_t));
     if (ht->ev[0] == NULL) {
-        fprintf(stderr, "Enlarging exponent vector for hash table failed\n");
-        fprintf(stderr, "for esz = %lu, segmentation fault will follow.\n", (unsigned long)esz);
+        fprintf(ERRSTREAM, "Enlarging exponent vector for hash table failed\n");
+        fprintf(ERRSTREAM, "for esz = %lu, segmentation fault will follow.\n", (unsigned long)esz);
     }
     /* due to realloc we have to reset ALL ev entries,
      * memory might have been moved */
@@ -354,8 +355,8 @@ static void enlarge_hash_table(
         const hl_t hsz  = ht->hsz;
         ht->hmap  = realloc(ht->hmap, hsz * sizeof(hi_t));
         if (ht->hmap == NULL) {
-            fprintf(stderr, "Enlarging hash table failed for hsz = %lu,\n", (unsigned long)hsz);
-            fprintf(stderr, "segmentation fault will follow.\n");
+            fprintf(ERRSTREAM, "Enlarging hash table failed for hsz = %lu,\n", (unsigned long)hsz);
+            fprintf(ERRSTREAM, "segmentation fault will follow.\n");
         }
         memset(ht->hmap, 0, hsz * sizeof(hi_t));
         const hi_t mod =  (hi_t )(hsz-1);
@@ -377,12 +378,12 @@ static void enlarge_hash_table(
         }
     } else {
         if (ht->hsz == (hl_t)pow(2,32)) {
-          printf("Exponent space is now 2^32 elements wide, we cannot\n");
-          printf("enlarge the hash table any further, thus fill in gets\n");
-          printf("over 50%% and performance of hashing may get worse.\n");
+          fprintf(ERRSTREAM, "Exponent space is now 2^32 elements wide, we cannot\n");
+          fprintf(ERRSTREAM, "enlarge the hash table any further, thus fill in gets\n");
+          fprintf(ERRSTREAM, "over 50%% and performance of hashing may get worse.\n");
         } else {
-          printf("Hash table is full, we can no longer enlarge\n");
-          printf("Segmentation fault will follow.\n");
+          fprintf(ERRSTREAM, "Hash table is full, we can no longer enlarge\n");
+          fprintf(ERRSTREAM, "Segmentation fault will follow.\n");
           free(ht->hmap);
           ht->hmap  = NULL;
         }
@@ -409,7 +410,7 @@ static inline sdm_t generate_short_divmask(
       ctr++;
     }
   }
- 
+
   return res;
 }
 
@@ -892,18 +893,18 @@ static inline void reinitialize_hash_table(
         ht->hd  = realloc(ht->hd, esz * sizeof(hd_t));
         ht->ev  = realloc(ht->ev, esz * sizeof(exp_t *));
         if (ht->ev == NULL) {
-            fprintf(stderr, "Computation needs too much memory on this machine,\n");
-            fprintf(stderr, "could not reinitialize exponent vector for hash table,\n");
-            fprintf(stderr, "esz = %lu, segmentation fault will follow.\n", (unsigned long)esz);
+            fprintf(ERRSTREAM, "Computation needs too much memory on this machine,\n");
+            fprintf(ERRSTREAM, "could not reinitialize exponent vector for hash table,\n");
+            fprintf(ERRSTREAM, "esz = %lu, segmentation fault will follow.\n", (unsigned long)esz);
         }
         /* note: memory is allocated as one big block, so reallocating
          *       memory from evl[0] is enough    */
         ht->ev[0]  = realloc(ht->ev[0],
                 esz * (unsigned long)evl * sizeof(exp_t));
         if (ht->ev[0] == NULL) {
-            fprintf(stderr, "Exponent storage needs too much memory on this machine,\n");
-            fprintf(stderr, "reinitialization failed, esz = %lu\n", (unsigned long)esz);
-            fprintf(stderr, "segmentation fault will follow.\n");
+            fprintf(ERRSTREAM, "Exponent storage needs too much memory on this machine,\n");
+            fprintf(ERRSTREAM, "reinitialization failed, esz = %lu\n", (unsigned long)esz);
+            fprintf(ERRSTREAM, "segmentation fault will follow.\n");
         }
         /* due to realloc we have to reset ALL evl entries, memory might be moved */
         for (i = 1; i < esz; ++i) {
@@ -1076,7 +1077,7 @@ static inline void insert_in_basis_hash_table_pivots(
 
     /* const hd_t * const hds    = sht->hd; */
     exp_t * const * const evs = sht->ev;
-    
+
     exp_t *evt  = (exp_t *)malloc((unsigned long)evl * sizeof(exp_t));
     for (l = OFFSET; l < len; ++l) {
         memcpy(evt, evs[hcm[row[l]]],
@@ -1125,7 +1126,7 @@ static inline void insert_multiplied_poly_in_hash_table(
 
     exp_t * const *ev1      = ht1->ev;
     /* const hd_t * const hd1  = ht1->hd; */
-    
+
     exp_t **ev2     = ht2->ev;
 
     l = OFFSET;
@@ -1254,16 +1255,16 @@ static void reset_hash_table(
 
     ht->ev  = calloc(esz, sizeof(exp_t *));
     if (ht->ev == NULL) {
-        fprintf(stderr, "Computation needs too much memory on this machine,\n");
-        fprintf(stderr, "cannot reset ht->ev, esz = %lu\n", (unsigned long)esz);
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Computation needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "cannot reset ht->ev, esz = %lu\n", (unsigned long)esz);
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     exp_t *tmp  = (exp_t *)malloc(
             (unsigned long)evl * esz * sizeof(exp_t));
     if (tmp == NULL) {
-        fprintf(stderr, "Computation needs too much memory on this machine,\n");
-        fprintf(stderr, "resetting table failed, esz = %lu\n", (unsigned long)esz);
-        fprintf(stderr, "segmentation fault will follow.\n");
+        fprintf(ERRSTREAM, "Computation needs too much memory on this machine,\n");
+        fprintf(ERRSTREAM, "resetting table failed, esz = %lu\n", (unsigned long)esz);
+        fprintf(ERRSTREAM, "segmentation fault will follow.\n");
     }
     for (k = 0; k < esz; ++k) {
         ht->ev[k]  = tmp + k*evl;

--- a/src/neogb/io.c
+++ b/src/neogb/io.c
@@ -20,6 +20,7 @@
 
 
 #include "io.h"
+#include "../msolve/streams.h"
 
 /* See exponent vector description in data.h for more information. */
 static inline void set_exponent_vector(
@@ -474,7 +475,7 @@ void return_zero(
             (unsigned long)1 * sizeof(int32_t));
     cf[0]   =   0;
     } else {
-        fprintf(stderr, "We only support finite fields.\n");
+        fprintf(ERRSTREAM, "We only support finite fields.\n");
     }
 }
 
@@ -513,7 +514,7 @@ static int64_t export_data(
     nelts = lml;
 
     if (nelts > (int64_t)(pow(2, 31))) {
-        printf("Basis has more than 2^31 elements, cannot store it.\n");
+        fprintf(ERRSTREAM, "Basis has more than 2^31 elements, cannot store it.\n");
         return 0;
     }
 
@@ -661,60 +662,60 @@ int validate_input_data(
 {
     /* biggest prime msovle can handle */
     if (*field_charp > 4294967291) {
-        fprintf(stderr, "Field characteristic not valid.\n");
+        fprintf(ERRSTREAM, "Field characteristic not valid.\n");
         return 0;
     }
     if (*nr_varsp < 0) {
-        fprintf(stderr, "Number of variables not valid.\n");
+        fprintf(ERRSTREAM, "Number of variables not valid.\n");
         return 0;
     }
     if (*nr_gensp < 1) {
-        fprintf(stderr, "Number of generators not valid.\n");
+        fprintf(ERRSTREAM, "Number of generators not valid.\n");
         return 0;
     }
     if (*nr_nfp < 0 || *nr_nfp >= *nr_gensp) {
-        fprintf(stderr, "Number of normal forms not valid.\n");
+        fprintf(ERRSTREAM, "Number of normal forms not valid.\n");
         return 0;
     }
     if (*mon_orderp < 0) {
-        fprintf(stderr, "Fixes monomial order to DRL.\n");
+        fprintf(ERRSTREAM, "Fixes monomial order to DRL.\n");
         *mon_orderp =   0;
     }
     if (*elim_block_lenp < 0) {
-        fprintf(stderr, "Fixes elim block order length to 0.\n");
+        fprintf(ERRSTREAM, "Fixes elim block order length to 0.\n");
         *elim_block_lenp =   0;
     }
     if (*ht_sizep < 0) {
-        fprintf(stderr, "Fixes initial hash table size to 2^17.\n");
+        fprintf(ERRSTREAM, "Fixes initial hash table size to 2^17.\n");
         *ht_sizep   =   17;
     }
     if (*nr_threadsp < 0) {
-        fprintf(stderr, "Fixes number of threads to 1.\n");
+        fprintf(ERRSTREAM, "Fixes number of threads to 1.\n");
         *nr_threadsp    =   1;
     }
     if (*max_nr_pairsp < 0) {
-        fprintf(stderr, "Fixes maximal number of spairs chosen to all possible.\n");
+        fprintf(ERRSTREAM, "Fixes maximal number of spairs chosen to all possible.\n");
         *max_nr_pairsp  =   0;
     }
     if (*la_optionp != 1 && *la_optionp != 2 &&
             *la_optionp != 42 && *la_optionp != 44) {
-        fprintf(stderr, "Fixes linear algebra option to exact sparse.\n");
+        fprintf(ERRSTREAM, "Fixes linear algebra option to exact sparse.\n");
         *la_optionp =   2;
     }
     if (*use_signaturesp < 0 || *use_signaturesp > 3) {
-        fprintf(stderr, "Usage of signature not valid, disabled.\n");
+        fprintf(ERRSTREAM, "Usage of signature not valid, disabled.\n");
         *use_signaturesp = 0;
     }
     if (*reduce_gbp < 0 || *reduce_gbp > 1) {
-        fprintf(stderr, "Fixes reduction of GB to 0 (false).\n");
+        fprintf(ERRSTREAM, "Fixes reduction of GB to 0 (false).\n");
         *reduce_gbp =   0;
     }
     if(*truncate_liftingp < 0){
-        fprintf(stderr, "Removes truncation of lifted Groebner bases\n");
+        fprintf(ERRSTREAM, "Removes truncation of lifted Groebner bases\n");
         *truncate_liftingp = 0;
     }
     if (*info_levelp < 0 || *info_levelp > 2) {
-        fprintf(stderr, "Fixes info level to no output.\n");
+        fprintf(ERRSTREAM, "Fixes info level to no output.\n");
         *info_levelp    =   0;
     }
     const int ngens     =   *nr_gensp;
@@ -795,7 +796,7 @@ int32_t check_and_set_meta_data(
             || lens == NULL
             || cfs == NULL
             || exps == NULL) {
-      fprintf(stderr, "Problem with meta data [%d, %d, %d]\n",
+      fprintf(ERRSTREAM, "Problem with meta data [%d, %d, %d]\n",
               (lens==NULL),(cfs==NULL),(exps==NULL));
       return 1;
     }
@@ -830,7 +831,7 @@ int32_t check_and_set_meta_data(
     /* elimination block order? If so, store the blocks length */
     st->nev = elim_block_len >= 0 ? elim_block_len : 0;
     if (st->nev >= st->nvars) {
-        fprintf(stderr,"error: Too large elimination block.\n");
+        fprintf(ERRSTREAM,"error: Too large elimination block.\n");
         exit(1);
     }
     /* set hash table size */

--- a/src/neogb/la_ff_16.c
+++ b/src/neogb/la_ff_16.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "../msolve/streams.h"
 
 /* That's also enough if AVX512 is avaialable on the system */
 #if defined HAVE_AVX2
@@ -1154,7 +1155,7 @@ static void exact_sparse_reduced_echelon_form_ff_16(
         }
         mat->np = 0;
         if (st->info_level > 0) {
-            fprintf(stderr, "Zero reduction while applying tracer, bad prime.\n");
+            fprintf(ERRSTREAM, "Zero reduction while applying tracer, bad prime.\n");
         }
         return;
     }
@@ -1286,7 +1287,7 @@ static int exact_application_sparse_reduced_echelon_form_ff_16(
                 npiv  = mat->tr[i]  = reduce_dense_row_by_known_pivots_sparse_ff_16(
                         drl, mat, bs, pivs, sc, i, mh, bi, 0, st->fc);
                 if (!npiv) {
-                    fprintf(stderr, "Unlucky prime detected, row reduced to zero.");
+                    fprintf(ERRSTREAM, "Unlucky prime detected, row reduced to zero.");
                     flag  = 0;
                 }
 
@@ -2000,8 +2001,8 @@ static void probabilistic_sparse_linear_algebra_ff_16(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2033,8 +2034,8 @@ static void exact_sparse_linear_algebra_ff_16(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2065,8 +2066,8 @@ static int exact_application_sparse_linear_algebra_ff_16(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 
     return ret;
@@ -2098,8 +2099,8 @@ static void exact_trace_sparse_linear_algebra_ff_16(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2122,7 +2123,7 @@ static void exact_sparse_dense_linear_algebra_ff_16(
     /* generate updated dense D part via reduction of CD with AB */
     cf16_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_16(mat, bs, st);
-    if (mat->np > 0) {      
+    if (mat->np > 0) {
         dm  = exact_dense_linear_algebra_ff_16(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_16(dm, ncr, st->fc);
     }
@@ -2148,8 +2149,8 @@ static void exact_sparse_dense_linear_algebra_ff_16(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2172,7 +2173,7 @@ static void probabilistic_sparse_dense_linear_algebra_ff_16_2(
     /* generate updated dense D part via reduction of CD with AB */
     cf16_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_16(mat, bs, st);
-    if (mat->np > 0) {      
+    if (mat->np > 0) {
         dm  = probabilistic_dense_linear_algebra_ff_16(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_16(dm, mat->ncr, st->fc);
     }
@@ -2198,8 +2199,8 @@ static void probabilistic_sparse_dense_linear_algebra_ff_16_2(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2246,8 +2247,8 @@ static void probabilistic_sparse_dense_linear_algebra_ff_16(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2265,7 +2266,7 @@ static void interreduce_matrix_rows_ff_16(
 
     /* adjust displaying timings for statistic printout */
     if (st->info_level > 1) {
-        printf("                          ");
+        fprintf(VERBSTREAM, "                          ");
     }
 
     /* for interreduction steps like the final basis reduction we

--- a/src/neogb/la_ff_32.c
+++ b/src/neogb/la_ff_32.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "../msolve/streams.h"
 
 /* That's also enough if AVX512 is available on the system */
 #if defined HAVE_AVX2
@@ -2703,7 +2704,7 @@ static void exact_sparse_reduced_echelon_form_ff_32(
         }
         mat->np = 0;
         if (st->info_level > 0) {
-            fprintf(stderr, "Zero reduction while applying tracer, bad prime.\n");
+            fprintf(ERRSTREAM, "Zero reduction while applying tracer, bad prime.\n");
         }
         return;
     }
@@ -2869,9 +2870,9 @@ static void exact_sparse_reduced_echelon_form_sat_ff_32(
     len_t ctr = 0;
 
     if (st->info_level > 1) {
-      printf("        normal form time");
+      fprintf(VERBSTREAM, "        normal form time");
     }
-    print_sat_nf_round_timings(stdout, st, rt, ct);
+    print_sat_nf_round_timings(VERBSTREAM, st, rt, ct);
     /* compute kernel */
     for (i = 0; i < sat->ld; ++i) {
         if (sat->hm[i] != NULL) {
@@ -3191,7 +3192,7 @@ static int exact_application_sparse_reduced_echelon_form_ff_32(
                 npiv  = mat->tr[i]  = reduce_dense_row_by_known_pivots_sparse_ff_32(
                         drl, mat, bs, pivs, sc, i, mh, bi, 0, st);
                 if (!npiv) {
-                    fprintf(stderr, "Unlucky prime detected, row reduced to zero.");
+                    fprintf(ERRSTREAM, "Unlucky prime detected, row reduced to zero.");
                     flag  = 0;
                     break;
                 }
@@ -3924,8 +3925,8 @@ static void probabilistic_sparse_linear_algebra_ff_32(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -3983,8 +3984,8 @@ static void exact_sparse_linear_algebra_ff_32(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -4064,8 +4065,8 @@ static int exact_application_sparse_linear_algebra_ff_32(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 
     return ret;
@@ -4097,8 +4098,8 @@ static void exact_trace_sparse_linear_algebra_ff_32(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -4147,8 +4148,8 @@ static void exact_sparse_dense_linear_algebra_ff_32(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -4197,8 +4198,8 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32_2(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -4245,8 +4246,8 @@ static void probabilistic_sparse_dense_linear_algebra_ff_32(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -4264,7 +4265,7 @@ static void interreduce_matrix_rows_ff_32(
 
     /* adjust displaying timings for statistic printout */
     if (st->info_level > 1) {
-        printf("                          ");
+        fprintf(VERBSTREAM, "                          ");
     }
 
     mat->tr = realloc(mat->tr, (uint64_t)ncols * sizeof(hm_t *));

--- a/src/neogb/la_ff_8.c
+++ b/src/neogb/la_ff_8.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "../msolve/streams.h"
 
 /* That's also enough if AVX512 is avaialable on the system */
 #if defined HAVE_AVX2
@@ -1109,7 +1110,7 @@ static int exact_application_sparse_reduced_echelon_form_ff_8(
                 npiv  = mat->tr[i]  = reduce_dense_row_by_known_pivots_sparse_ff_8(
                         drl, mat, bs, pivs, sc, i, mh, bi, 0, st->fc);
                 if (!npiv) {
-                    fprintf(stderr, "Unlucky prime detected, row reduced to zero.");
+                    fprintf(ERRSTREAM, "Unlucky prime detected, row reduced to zero.");
                     flag = 0;
                 }
 
@@ -1427,7 +1428,7 @@ static void exact_sparse_reduced_echelon_form_ff_8(
         }
         mat->np = 0;
         if (st->info_level > 0) {
-            fprintf(stderr, "Zero reduction while applying tracer, bad prime.\n");
+            fprintf(ERRSTREAM, "Zero reduction while applying tracer, bad prime.\n");
         }
         return;
     }
@@ -2129,8 +2130,8 @@ static void probabilistic_sparse_linear_algebra_ff_8(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2161,8 +2162,8 @@ static int exact_application_sparse_linear_algebra_ff_8(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 
     return ret;
@@ -2194,8 +2195,8 @@ static void exact_trace_sparse_linear_algebra_ff_8(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2225,8 +2226,8 @@ static void exact_sparse_linear_algebra_ff_8(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2249,7 +2250,7 @@ static void exact_sparse_dense_linear_algebra_ff_8(
     /* generate updated dense D part via reduction of CD with AB */
     cf8_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_8(mat, bs, st);
-    if (mat->np > 0) {      
+    if (mat->np > 0) {
         dm  = exact_dense_linear_algebra_ff_8(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_8(dm, ncr, st->fc);
     }
@@ -2275,8 +2276,8 @@ static void exact_sparse_dense_linear_algebra_ff_8(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2299,7 +2300,7 @@ static void probabilistic_sparse_dense_linear_algebra_ff_8_2(
     /* generate updated dense D part via reduction of CD with AB */
     cf8_t **dm;
     dm  = sparse_AB_CD_linear_algebra_ff_8(mat, bs, st);
-    if (mat->np > 0) {      
+    if (mat->np > 0) {
         dm  = probabilistic_dense_linear_algebra_ff_8(dm, mat, st);
         dm  = interreduce_dense_matrix_ff_8(dm, mat->ncr, st->fc);
     }
@@ -2325,8 +2326,8 @@ static void probabilistic_sparse_dense_linear_algebra_ff_8_2(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2373,8 +2374,8 @@ static void probabilistic_sparse_dense_linear_algebra_ff_8(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%9d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -2392,7 +2393,7 @@ static void interreduce_matrix_rows_ff_8(
 
     /* adjust displaying timings for statistic printout */
     if (st->info_level > 1) {
-        printf("                          ");
+        fprintf(VERBSTREAM, "                          ");
     }
 
     /* for interreduction steps like the final basis reduction we
@@ -2457,7 +2458,7 @@ static void interreduce_matrix_rows_ff_8(
     if (free_basis != 0) {
         /* free now all polynomials in the basis and reset bs->ld to 0. */
         free_basis_elements(bs);
-    }    
+    }
     free(mat->rr);
     mat->rr = NULL;
     st->np = mat->np = nrows;

--- a/src/neogb/la_qq.c
+++ b/src/neogb/la_qq.c
@@ -19,6 +19,7 @@
  * Mohab Safey El Din */
 
 #include "data.h"
+#include "../msolve/streams.h"
 
 static inline mpz_t *remove_content_of_sparse_matrix_row_qq(
         mpz_t *row,
@@ -762,8 +763,8 @@ static void exact_sparse_linear_algebra_ab_first_qq(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%7d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%7d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 static void exact_sparse_linear_algebra_qq(
@@ -792,8 +793,8 @@ static void exact_sparse_linear_algebra_qq(
 
     st->num_zerored += (mat->nrl - mat->np);
     if (st->info_level > 1) {
-        printf("%7d new %7d zero", mat->np, mat->nrl - mat->np);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%7d new %7d zero", mat->np, mat->nrl - mat->np);
+        fflush(VERBSTREAM);
     }
 }
 
@@ -811,7 +812,7 @@ static void interreduce_matrix_rows_qq(
 
     /* adjust displaying timings for statistic printout */
     if (st->info_level > 1) {
-        printf("                        ");
+        fprintf(VERBSTREAM, "                        ");
     }
     mat->tr = realloc(mat->tr, (unsigned long)ncols * sizeof(hm_t *));
 

--- a/src/neogb/meta_data.c
+++ b/src/neogb/meta_data.c
@@ -20,6 +20,8 @@
 
 
 #include "meta_data.h"
+#include "../msolve/streams.h"
+
 md_t *copy_meta_data(
 		     const md_t * const gmd,
 		     const int32_t prime
@@ -87,15 +89,15 @@ void print_tracer_statistics(
 {
     if (st->trace_level == APPLY_TRACER) {
         /* if(st->info_level > 1){ */
-        /*     fprintf(stderr, "Learning phase %.2f Gops/sec\n", */
+        /*     fprintf(ERRSTREAM, "Learning phase %.2f Gops/sec\n", */
         /*             (st->trace_nr_add+st->trace_nr_mult)/1000.0/1000.0/(realtime()-rt)); */
         /* } */
         if(st->info_level > 2){
-            fprintf(stderr, "------------------------------------------\n");
-            fprintf(stderr, "#ADDITIONS       %13lu\n", (unsigned long)st->trace_nr_add * 1000);
-            fprintf(stderr, "#MULTIPLICATIONS %13lu\n", (unsigned long)st->trace_nr_mult * 1000);
-            fprintf(stderr, "#REDUCTIONS      %13lu\n", (unsigned long)st->trace_nr_red);
-            fprintf(stderr, "------------------------------------------\n");
+            fprintf(ERRSTREAM, "------------------------------------------\n");
+            fprintf(ERRSTREAM, "#ADDITIONS       %13lu\n", (unsigned long)st->trace_nr_add * 1000);
+            fprintf(ERRSTREAM, "#MULTIPLICATIONS %13lu\n", (unsigned long)st->trace_nr_mult * 1000);
+            fprintf(ERRSTREAM, "#REDUCTIONS      %13lu\n", (unsigned long)st->trace_nr_red);
+            fprintf(ERRSTREAM, "------------------------------------------\n");
         }
     }
 }
@@ -198,7 +200,7 @@ void print_sat_nf_round_timings(
         )
 {
     if (st->info_level > 1) {
-        printf("%15.2f | %-13.2f\n",
+        fprintf(VERBSTREAM, "%15.2f | %-13.2f\n",
                 realtime() - rrt, cputime() - crt);
     }
 }
@@ -211,7 +213,7 @@ void print_sat_round_timings(
         )
 {
     if (st->info_level > 1) {
-        printf("%10.2f | %-13.2f\n",
+        fprintf(VERBSTREAM, "%10.2f | %-13.2f\n",
                 realtime() - rrt, cputime() - crt);
     }
 }
@@ -224,7 +226,7 @@ void print_round_timings(
         )
 {
     if (st->info_level > 1) {
-        printf("%13.2f | %-13.2f\n",
+        fprintf(VERBSTREAM, "%13.2f | %-13.2f\n",
                 realtime() - rrt, cputime() - crt);
     }
 }
@@ -235,7 +237,7 @@ void print_round_information_footer(
         )
 {
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 -----------------------------------------------------\n");
     }
 }
@@ -248,8 +250,8 @@ static void print_current_trace_meta_data(
     len_t deg = md->tr->td[rd].deg;
 
     if (md->info_level > 1) {
-        printf("%9d  %6d  ", rd+1, deg);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%9d  %6d  ", rd+1, deg);
+        fflush(VERBSTREAM);
     }
 }
 

--- a/src/neogb/modular.c
+++ b/src/neogb/modular.c
@@ -20,6 +20,7 @@
 
 
 #include "modular.h"
+#include "../msolve/streams.h"
 
 static int minimal_traced_lm_is_equal(
         const hm_t *lmh,
@@ -147,8 +148,8 @@ void reduce_basis_no_hash_table_switching(
 
     /* generate hash <-> column mapping */
     if (st->info_level > 1) {
-        printf("reduce basis       ");
-        fflush(stdout);
+        fprintf(VERBSTREAM, "reduce basis       ");
+        fflush(VERBSTREAM);
     }
     convert_hashes_to_columns(mat, st, sht);
     mat->nc = mat->ncl + mat->ncr;
@@ -189,11 +190,11 @@ start:
     st->reduce_gb_ctime = ct1 - ct0;
     st->reduce_gb_rtime = rt1 - rt0;
     if (st->info_level > 1) {
-        printf("%13.2f sec\n", rt1-rt0);
+        fprintf(VERBSTREAM, "%13.2f sec\n", rt1-rt0);
     }
 
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
 }
@@ -243,15 +244,15 @@ bs_t *f4_trace_application_phase(
     bs->ld  = st->ngens;
 
     if(st->info_level>1){
-      printf("Application phase with prime p = %d, overall there are %u rounds\n",
+      fprintf(VERBSTREAM, "Application phase with prime p = %d, overall there are %u rounds\n",
              fc, trace->ltd);
     }
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
     if (st->info_level > 1) {
-        printf("\nround   deg          mat          density \
+        fprintf(VERBSTREAM, "\nround   deg          mat          density \
           new data             time(rd)\n");
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
     for (round = 0; round < trace->ltd; ++round) {
@@ -264,9 +265,9 @@ bs_t *f4_trace_application_phase(
        * sorted correspondingly */
       generate_matrix_from_trace(mat, bs, st);
         if (st->info_level > 1) {
-            printf("%5d", round+1);
-            printf("%6u ", sht->ev[mat->tr[0][OFFSET]][DEG]);
-            fflush(stdout);
+            fprintf(VERBSTREAM, "%5d", round+1);
+            fprintf(VERBSTREAM, "%6u ", sht->ev[mat->tr[0][OFFSET]][DEG]);
+            fflush(VERBSTREAM);
         }
       convert_hashes_to_columns(mat, st, sht);
       /* linear algebra, depending on choice, see set_function_pointers() */
@@ -278,7 +279,7 @@ bs_t *f4_trace_application_phase(
       /* columns indices are mapped back to exponent hashes */
       if (mat->np > 0) {
           if (mat->np != trace->td[round].nlm) {
-              fprintf(stderr, "Wrong number of new elements when applying tracer.");
+              fprintf(ERRSTREAM, "Wrong number of new elements when applying tracer.");
               ret = 1;
               goto stop;
           }
@@ -286,7 +287,7 @@ bs_t *f4_trace_application_phase(
                   -1, mat, bs, bht, sht, st);
           for (i = 0; i < mat->np; ++i) {
               if (bs->hm[bs->ld+i][OFFSET] != trace->td[round].nlms[i]) {
-                  fprintf(stderr, "Wrong leading term for new element %u/%u.",
+                  fprintf(ERRSTREAM, "Wrong leading term for new element %u/%u.",
                           i, mat->np);
                   ret = 1;
                   goto stop;
@@ -301,11 +302,11 @@ bs_t *f4_trace_application_phase(
 
       rrt1 = realtime();
       if (st->info_level > 1) {
-        printf("%13.2f sec\n", rrt1-rrt0);
+        fprintf(VERBSTREAM, "%13.2f sec\n", rrt1-rrt0);
       }
     }
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
 
@@ -356,7 +357,7 @@ bs_t *f4_trace_application_phase(
     for (i = 0; i < bs->lml; ++i) {
         st->nterms_basis +=  (int64_t)bs->hm[bs->lmps[i]][LENGTH];
     }
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
 stop:
     /* free and clean up */
@@ -441,15 +442,15 @@ bs_t *f4sat_trace_application_test_phase(
     update_basis_f4(ps, bs, bht, st, st->ngens);
 
     if(st->info_level>1){
-        printf("Application phase with prime p = %d, overall there are %u rounds\n",
+        fprintf(VERBSTREAM, "Application phase with prime p = %d, overall there are %u rounds\n",
                 fc, trace->ltd);
     }
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
     if (st->info_level > 1) {
-        printf("\ndeg     sel   pairs        mat          density \
+        fprintf(VERBSTREAM, "\ndeg     sel   pairs        mat          density \
           new data             time(rd)\n");
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
     round = 1;
@@ -489,10 +490,10 @@ bs_t *f4sat_trace_application_test_phase(
         /* if we found a constant we are done, so remove all remaining pairs */
         rrt1 = realtime();
         if (st->info_level > 1) {
-            printf("%13.2f sec\n", rrt1-rrt0);
+            fprintf(VERBSTREAM, "%13.2f sec\n", rrt1-rrt0);
         }
         if (bs->constant  == 1) {
-            printf("basis is constant\n");
+            fprintf(VERBSTREAM, "basis is constant\n");
             ps->ld  = 0;
             break;
         }
@@ -513,7 +514,7 @@ bs_t *f4sat_trace_application_test_phase(
             if (mat->nru > 0) {
                 if (st->info_level > 1) {
                     /* printf("kernel computation "); */
-                    printf("%3u  compute kernel", sat_deg);
+                    fprintf(VERBSTREAM, "%3u  compute kernel", sat_deg);
                 }
                 /* int ctr = 0;
                  * for (int ii = 1; ii < sat->ld; ++ii) {
@@ -542,7 +543,7 @@ bs_t *f4sat_trace_application_test_phase(
 
                 if (kernel->ld > 0) {
                     if (st->info_level > 1) {
-                        printf("\n                                               ");
+                        fprintf(VERBSTREAM, "\n                                               ");
                     }
                     clear_matrix(mat);
                     /* interreduce kernel */
@@ -563,7 +564,7 @@ bs_t *f4sat_trace_application_test_phase(
                     update_basis_f4(ps, bs, bht, st, mat->np);
                     kernel->ld  = 0;
                     if (st->info_level > 1) {
-                        printf("   ");
+                        fprintf(VERBSTREAM, "   ");
                     }
                 }
                 /* columns indices are mapped back to exponent hashes */
@@ -605,12 +606,12 @@ bs_t *f4sat_trace_application_test_phase(
 
             rrt1 = realtime();
             if (st->info_level > 1) {
-                printf("%10.2f sec\n", rrt1-rrt0);
+                fprintf(VERBSTREAM, "%10.2f sec\n", rrt1-rrt0);
             }
         }
     }
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
                 ----------------------------------------\n");
     }
     /* remove possible redudant elements */
@@ -647,7 +648,7 @@ bs_t *f4sat_trace_application_test_phase(
     for (i = 0; i < bs->lml; ++i) {
         st->nterms_basis +=  (int64_t)bs->hm[bs->lmps[i]][LENGTH];
     }
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
     /* free and clean up */
     free(hcmm);
@@ -731,12 +732,12 @@ bs_t *f4sat_trace_application_phase(
     update_lm(bs, bht, st);
 
     if(st->info_level>1){
-        printf("Application phase with prime p = %d\n%u f4 rounds and %u saturation rounds\n",
+        fprintf(VERBSTREAM, "Application phase with prime p = %d\n%u f4 rounds and %u saturation rounds\n",
                 fc, trace->ltd, trace->rld);
     }
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
-    print_round_information_header(stdout, st);
+    print_round_information_header(VERBSTREAM, st);
     round = 0;
     for (; round < trace->ltd; ++round) {
         rrt = realtime();
@@ -750,9 +751,9 @@ bs_t *f4sat_trace_application_phase(
         generate_matrix_from_trace(mat, bs, st);
         st->trace_rd++;
         /* if (st->info_level > 1) {
-            printf("%5d", round+1);
-            printf("%6u ", sht->ev[mat->tr[0][OFFSET]][DEG]);
-            fflush(stdout);
+            fprintf(VERBSTREAM, "%5d", round+1);
+            fprintf(VERBSTREAM, "%6u ", sht->ev[mat->tr[0][OFFSET]][DEG]);
+            fflush(VERBSTREAM);
         } */
         convert_hashes_to_columns(mat, st, sht);
         /* linear algebra, depending on choice, see set_function_pointers() */
@@ -764,7 +765,7 @@ bs_t *f4sat_trace_application_phase(
         /* columns indices are mapped back to exponent hashes */
         if (mat->np > 0) {
             if (mat->np != trace->td[round].nlm) {
-                fprintf(stderr, "Wrong number of new elements when applying tracer.");
+                fprintf(ERRSTREAM, "Wrong number of new elements when applying tracer.");
                 ret = 1;
                 goto stop;
             }
@@ -772,7 +773,7 @@ bs_t *f4sat_trace_application_phase(
                     -1, mat, bs, bht, sht, st);
             for (i = 0; i < mat->np; ++i) {
                 if (bs->hm[bs->ld+i][OFFSET] != trace->td[round].nlms[i]) {
-                    fprintf(stderr, "Wrong leading term for new element %u/%u.",
+                    fprintf(ERRSTREAM, "Wrong leading term for new element %u/%u.",
                             i, mat->np);
                     ret = 1;
                     goto stop;
@@ -786,7 +787,7 @@ bs_t *f4sat_trace_application_phase(
          * so we do not need the rows anymore */
         clear_matrix(mat);
 
-        print_round_timings(stdout, st, rrt, crt);
+        print_round_timings(VERBSTREAM, st, rrt, crt);
         /* saturation step starts here */
         while (ctr < trace->rld && trace->rd[ctr]  ==  round) {
             ctr++;
@@ -808,7 +809,7 @@ bs_t *f4sat_trace_application_phase(
             if (mat->nru > 0) {
                 if (st->info_level > 1) {
                     /* printf("kernel computation "); */
-                    printf("sat %5u %7u  ", ctr, sat_deg);
+                    fprintf(VERBSTREAM, "sat %5u %7u  ", ctr, sat_deg);
                 }
                 /* int ctr = 0;
                  * for (int ii = 1; ii < sat->ld; ++ii) {
@@ -836,12 +837,12 @@ bs_t *f4sat_trace_application_phase(
                 compute_kernel_sat_ff_32(sat, mat, kernel, bs, st);
 
                 if (st->info_level > 1) {
-                    printf("%56d new kernel elements", kernel->ld);
-                    fflush(stdout);
+                    fprintf(VERBSTREAM, "%56d new kernel elements", kernel->ld);
+                    fflush(VERBSTREAM);
                     printf("\n                                               ");
                 }
                 if (kernel->ld == 0) {
-                    fprintf(stderr, "Trivial kernel when applying tracer.");
+                    fprintf(ERRSTREAM, "Trivial kernel when applying tracer.");
                     ret = 1;
                     goto stop;
                 }
@@ -897,10 +898,10 @@ bs_t *f4sat_trace_application_phase(
             }
             clean_hash_table(sht);
 
-            print_round_timings(stdout, st, rrt, crt);
+            print_round_timings(VERBSTREAM, st, rrt, crt);
         }
     }
-    print_round_information_footer(stdout, st);
+    print_round_information_footer(VERBSTREAM, st);
 
     /* apply non-redundant basis data from trace to basis
      * before interreduction */
@@ -931,7 +932,7 @@ bs_t *f4sat_trace_application_phase(
     for (i = 0; i < bs->lml; ++i) {
         st->nterms_basis +=  (int64_t)bs->hm[bs->lmps[i]][LENGTH];
     }
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
 stop:
     /* free and clean up */
@@ -1011,10 +1012,10 @@ bs_t *f4_trace_learning_phase(
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
     if (st->info_level > 1) {
-      printf("Learning phase with prime p = %d\n", fc);
-        printf("\ndeg     sel   pairs        mat          density \
+      fprintf(VERBSTREAM, "Learning phase with prime p = %d\n", fc);
+      fprintf(VERBSTREAM, "\ndeg     sel   pairs        mat          density \
           new data             time(rd)\n");
-        printf("-------------------------------------------------\
+      fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
     for (round = 1; ps->ld > 0; ++round) {
@@ -1057,11 +1058,11 @@ bs_t *f4_trace_learning_phase(
 
       rrt1 = realtime();
       if (st->info_level > 1) {
-        printf("%13.2f sec\n", rrt1-rrt0);
+        fprintf(VERBSTREAM, "%13.2f sec\n", rrt1-rrt0);
       }
     }
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
     /* remove possible redudant elements */
@@ -1109,7 +1110,7 @@ bs_t *f4_trace_learning_phase(
     st->f4_ctime = ct1 - ct0;
     st->f4_rtime = rt1 - rt0;
 
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
     /* free and clean up
      * note: we keep the basis hash table bht for all upcoming runs.
@@ -1222,7 +1223,7 @@ bs_t *f4sat_trace_learning_phase_1(
 
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
-    print_round_information_header(stdout, st);
+    print_round_information_header(VERBSTREAM, st);
     round = 1;
 end_sat_step:
     for (; ps->ld > 0; ++round) {
@@ -1254,12 +1255,12 @@ end_sat_step:
         update_basis_f4(ps, bs, bht, st, mat->np);
 
         if (bs->constant  == 1) {
-            printf("basis is constant\n");
+            fprintf(VERBSTREAM, "basis is constant\n");
             ps->ld  = 0;
             break;
         }
         clean_hash_table(sht);
-        print_round_timings(stdout, st, rrt, crt);
+        print_round_timings(VERBSTREAM, st, rrt, crt);
 
         /* saturation step starts here */
         if ((bs->mltdeg >= sat->hm[0][DEG] && sat_test != 0) || ps->ld == 0) {
@@ -1296,7 +1297,7 @@ end_sat_step:
                 if (mat->nru > 0) {
                     if (st->info_level > 1) {
                         /* printf("kernel computation "); */
-                        printf("%3u  compute kernel", sat_deg);
+                        fprintf(VERBSTREAM, "%3u  compute kernel", sat_deg);
                     }
                     convert_hashes_to_columns_sat(mat, sat, st, sht);
                     convert_multipliers_to_columns(&hcmm, sat, st, bht);
@@ -1305,13 +1306,13 @@ end_sat_step:
                     compute_kernel_sat_ff_32(sat, mat, kernel, bs, st);
 
                     if (st->info_level > 1) {
-                        printf("%56d new kernel elements", kernel->ld);
-                        fflush(stdout);
+                        fprintf(VERBSTREAM, "%56d new kernel elements", kernel->ld);
+                        fflush(VERBSTREAM);
                     }
 
                     if (kernel->ld > 0) {
                         if (st->info_level > 1) {
-                            printf("\n                                               ");
+                            fprintf(VERBSTREAM, "\n                                               ");
                         }
                         clear_matrix(mat);
                         /* interreduce kernel */
@@ -1345,7 +1346,7 @@ end_sat_step:
                         update_basis_f4(ps, bs, bht, st, mat->np);
                         kernel->ld  = 0;
                         if (st->info_level > 1) {
-                            printf("   ");
+                            fprintf(VERBSTREAM, "   ");
                         }
                     }
                     /* all rows in mat are now polynomials in the basis,
@@ -1381,7 +1382,7 @@ end_sat_step:
 
                 }
                 clean_hash_table(sht);
-                print_sat_round_timings(stdout, st, rrt, crt);
+                print_sat_round_timings(VERBSTREAM, st, rrt, crt);
 
                 if (bld != bs->ld) {
                     next_deg  = ii;
@@ -1393,7 +1394,7 @@ end_sat_step:
         }
     }
 
-    print_round_information_footer(stdout, st);
+    print_round_information_footer(VERBSTREAM, st);
 
     /* remove possible redudant elements */
     final_remove_redundant_elements(bs, st, bht);
@@ -1430,7 +1431,7 @@ end_sat_step:
     st->f4_rtime = realtime() - rt;
     st->f4_ctime = cputime() - ct;
 
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
     /* free and clean up
      * note: we keep the basis hash table bht for all upcoming runs.
@@ -1551,7 +1552,7 @@ bs_t *f4sat_trace_learning_phase_2(
 
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
-    print_round_information_header(stdout, st);
+    print_round_information_header(VERBSTREAM, st);
     round = 1;
     for (; ps->ld > 0; ++round) {
         /* check if we have already computed the
@@ -1595,12 +1596,12 @@ bs_t *f4sat_trace_learning_phase_2(
 
         /* if we found a constant we are done, so remove all remaining pairs */
         if (bs->constant  == 1) {
-            printf("basis is constant\n");
+            fprintf(VERBSTREAM, "basis is constant\n");
             ps->ld  = 0;
             break;
         }
         clean_hash_table(sht);
-        print_round_timings(stdout, st, rrt, crt);
+        print_round_timings(VERBSTREAM, st, rrt, crt);
 
         /* saturation step starts here */
         /* if (ts_ctr < trace->lts && minimal_traced_lm_is_equal(trace->ts[ts_ctr].lmh, trace->ts[ts_ctr].lml, bs) == 1) { */
@@ -1620,7 +1621,7 @@ bs_t *f4sat_trace_learning_phase_2(
             if (mat->nru > 0) {
                 if (st->info_level > 1) {
                     /* printf("kernel computation "); */
-                    printf("%3u  compute kernel", next_deg);
+                    fprintf(VERBSTREAM, "%3u  compute kernel", next_deg);
                 }
                 convert_hashes_to_columns_sat(mat, sat, st, sht);
                 convert_multipliers_to_columns(&hcmm, sat, st, bht);
@@ -1630,9 +1631,9 @@ bs_t *f4sat_trace_learning_phase_2(
                 compute_kernel_sat_ff_32(sat, mat, kernel, bs, st);
 
                 if (st->info_level > 1) {
-                    printf("%56d new kernel elements", kernel->ld);
-                    fflush(stdout);
-                    printf("\n                                               ");
+                    fprintf(VERBSTREAM, "%56d new kernel elements", kernel->ld);
+                    fflush(VERBSTREAM);
+                    fprintf(VERBSTREAM, "\n                                               ");
                 }
                 clear_matrix(mat);
                 /* interreduce kernel */
@@ -1665,7 +1666,7 @@ bs_t *f4sat_trace_learning_phase_2(
                 update_basis_f4(ps, bs, bht, st, mat->np);
                 kernel->ld  = 0;
                 if (st->info_level > 1) {
-                    printf("   ");
+                    fprintf(VERBSTREAM, "   ");
                 }
                 /* columns indices are mapped back to exponent hashes */
                 /* return_normal_forms_to_basis(
@@ -1703,12 +1704,12 @@ bs_t *f4sat_trace_learning_phase_2(
                 }
             }
             clean_hash_table(sht);
-            print_sat_round_timings(stdout, st, rrt, crt);
+            print_sat_round_timings(VERBSTREAM, st, rrt, crt);
             ts_ctr++;
         }
     }
 
-    print_round_information_footer(stdout, st);
+    print_round_information_footer(VERBSTREAM, st);
     /* remove possible redudant elements */
     final_remove_redundant_elements(bs, st, bht);
 
@@ -1748,7 +1749,7 @@ bs_t *f4sat_trace_learning_phase_2(
     st->f4_rtime = realtime() - rt;
     st->f4_ctime = cputime() - ct;
 
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
     /* free and clean up
      * note: we keep the basis hash table bht for all upcoming runs.
@@ -1818,9 +1819,9 @@ int64_t f4_trace_julia(
 {
     /* only for computations over the rationals */
     if (field_char != 0) {
-        fprintf(stderr, "Tracer only for computations over Q. Call\n");
-        fprintf(stderr, "standard F4 Algorithm for computations over\n");
-        fprintf(stderr, "finite fields.\n");
+        fprintf(ERRSTREAM, "Tracer only for computations over Q. Call\n");
+        fprintf(ERRSTREAM, "standard F4 Algorithm for computations over\n");
+        fprintf(ERRSTREAM, "finite fields.\n");
         return 1;
     }
 
@@ -1875,7 +1876,7 @@ int64_t f4_trace_julia(
     free(invalid_gens);
     invalid_gens = NULL;
 
-    print_initial_statistics(stdout, st);
+    print_initial_statistics(VERBSTREAM, st);
 
     /* for faster divisibility checks, needs to be done after we have
      * read some input data for applying heuristics */
@@ -1975,9 +1976,9 @@ bs_t *modular_f4(
     /* let's start the f4 rounds,  we are done when no more spairs
      * are left in the pairset */
     if (st->info_level > 1) {
-        printf("\ndeg     sel   pairs        mat          density \
+        fprintf(VERBSTREAM, "\ndeg     sel   pairs        mat          density \
           new data             time(rd)\n");
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
     for (round = 1; ps->ld > 0; ++round) {
@@ -2013,11 +2014,11 @@ bs_t *modular_f4(
 
       rrt1 = realtime();
       if (st->info_level > 1) {
-        printf("%13.2f sec\n", rrt1-rrt0);
+        fprintf(VERBSTREAM, "%13.2f sec\n", rrt1-rrt0);
       }
     }
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------------------\n");
     }
 
@@ -2057,7 +2058,7 @@ bs_t *modular_f4(
     for (i = 0; i < bs->lml; ++i) {
         st->nterms_basis +=  (int64_t)bs->hm[bs->lmps[i]][LENGTH];
     }
-    get_and_print_final_statistics(stdout, st, bs);
+    get_and_print_final_statistics(VERBSTREAM, st, bs);
 
     /* free and clean up */
     free(hcm);

--- a/src/neogb/nf.c
+++ b/src/neogb/nf.c
@@ -20,6 +20,7 @@
 
 
 #include "nf.h"
+#include "../msolve/streams.h"
 /* 31-bit implementation only at the moment */
 void get_normal_form_matrix(
         const bs_t * const tbr,
@@ -95,8 +96,8 @@ bs_t *core_nf(
      * so we do not need the rows anymore */
     clear_matrix(mat);
 
-    print_round_timings(stdout, md, rt, ct);
-    print_round_information_footer(stdout, md);
+    print_round_timings(VERBSTREAM, md, rt, ct);
+    print_round_information_footer(VERBSTREAM, md);
 
     /* free and clean up */
     free(md->hcm);
@@ -164,7 +165,7 @@ int64_t export_nf(
         return 1;
     }
     if (success == 0) {
-        fprintf(stderr,"Bad input data, stopped computation.\n");
+        fprintf(ERRSTREAM,"Bad input data, stopped computation.\n");
         exit(1);
     }
     if (bs_is_gb == 1) {
@@ -178,7 +179,7 @@ int64_t export_nf(
         bs = core_gba(bs, md, &err, md->fc);
 
         if (err) {
-            fprintf(stderr,"Problem with F4, stopped computation.\n");
+            fprintf(ERRSTREAM,"Problem with F4, stopped computation.\n");
             exit(1);
         }
     }
@@ -197,7 +198,7 @@ int64_t export_nf(
     tbr = core_nf(tbr, md, mul, bs, &err);
 
     if (err) {
-        fprintf(stderr,"Problem with normalform, stopped computation.\n");
+        fprintf(ERRSTREAM,"Problem with normalform, stopped computation.\n");
         exit(1);
     }
 
@@ -208,7 +209,7 @@ int64_t export_nf(
     md->nf_ctime = cputime() - ct;
     md->nf_rtime = realtime() - rt;
 
-    get_and_print_final_statistics(stderr, md, tbr);
+    get_and_print_final_statistics(ERRSTREAM, md, tbr);
 
     /* free and clean up */
     free_shared_hash_data(bht);

--- a/src/neogb/sba.c
+++ b/src/neogb/sba.c
@@ -20,6 +20,7 @@
 
 
 #include "sba.h"
+#include "../msolve/streams.h"
 
 static inline crit_t *initialize_signature_criteria(
         const md_t * const st
@@ -401,7 +402,7 @@ static inline void add_row_with_signature(
     smat->cr[cld]           = (hm_t *)malloc(
             (len + SM_OFFSET) * sizeof(hm_t));
     /* copy polynomial data, take a look at the difference between
-     * the meta data stored in hm arrays from bs and the 
+     * the meta data stored in hm arrays from bs and the
      * meta data stored in signature-based smat rows. */
     memcpy(smat->cr[cld]+SM_PRE,bs->hm[pos]+PRELOOP,
             (len + OFFSET - PRELOOP) * sizeof(hm_t));
@@ -680,9 +681,9 @@ int core_sba_schreyer(
             initial_input_cmp_sig, ht);
 
     if (st->info_level > 1) {
-        printf("\n deg           mat          density \
+        fprintf(VERBSTREAM, "\n deg           mat          density \
           new data              time(rd)\n");
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------\n");
     }
     st->current_rd  =   0;
@@ -721,8 +722,8 @@ int core_sba_schreyer(
         smat->cd++;
 
         if (st->info_level > 1) {
-            printf("%7d new %7d zero", smat->nlm, smat->nz);
-            fflush(stdout);
+            fprintf(VERBSTREAM, "%7d new %7d zero", smat->nlm, smat->nz);
+            fflush(VERBSTREAM);
         }
 
         /* if we found a constant we are done, if we have added no new elements
@@ -732,14 +733,14 @@ int core_sba_schreyer(
         }
         rrt1 = realtime();
         if (st->info_level > 1) {
-            printf("%13.2f sec\n", rrt1-rrt0);
+            fprintf(VERBSTREAM, "%13.2f sec\n", rrt1-rrt0);
         }
     }
     /* Note: We cannot free all signature related data at this point, maybe
      * we terminated too early and need to further compute in higher degrees. */
 
     if (st->info_level > 1) {
-        printf("-------------------------------------------------\
+        fprintf(VERBSTREAM, "-------------------------------------------------\
 ----------------------------\n");
     }
     /* fully reduce elements in basis. */
@@ -758,9 +759,9 @@ int core_sba_schreyer(
     free_signature_criteria(&rew, st);
     free(hcm);
 
-    printf("size of basis     %7u\n", bs->ld);
-    printf("#syzygy criteria  %7ld\n", (long)st->num_syz_crit);
-    printf("#rewrite criteria %7ld\n", (long)st->num_rew_crit);
+    fprintf(VERBSTREAM, "size of basis     %7u\n", bs->ld);
+    fprintf(VERBSTREAM, "#syzygy criteria  %7ld\n", (long)st->num_syz_crit);
+    fprintf(VERBSTREAM, "#rewrite criteria %7ld\n", (long)st->num_rew_crit);
 
     return 1;
 }

--- a/src/neogb/symbol.c
+++ b/src/neogb/symbol.c
@@ -21,12 +21,14 @@
 
 #include "data.h"
 
+#include "../msolve/streams.h"
+
 #ifdef HAVE_AVX2
 #include <immintrin.h>
 #endif
 
 /* select_all_pairs() is unused at the moment */
-#if 0 
+#if 0
 static void select_all_spairs(
         mat_t *mat,
         const bs_t * const bs,
@@ -62,10 +64,10 @@ static void select_all_spairs(
     /* now do maximal selection if it applies */
 
     nps = psl->ld;
-    
+
     if (st->info_level > 1) {
-        printf("%3d  %6d %7d", 0, nps, psl->ld);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%3d  %6d %7d", 0, nps, psl->ld);
+        fflush(VERBSTREAM);
     }
     /* statistics */
     st->num_pairsred  +=  nps;
@@ -119,7 +121,7 @@ static void select_all_spairs(
          * lcm we add exactly one row to mat->rr */
         rrows[nrr]  = multiplied_poly_to_matrix_row(sht, bht, h, etmp, b);
         /* track trace information ? */
-        if (tht != NULL) { 
+        if (tht != NULL) {
            rrows[nrr][BINDEX]  = prev;
             if (tht->eld == tht->esz-1) {
                 enlarge_hash_table(tht);
@@ -128,7 +130,7 @@ static void select_all_spairs(
         }
 
         /* mark lcm column as lead term column */
-        sht->hd[rrows[nrr++][OFFSET]].idx = 2; 
+        sht->hd[rrows[nrr++][OFFSET]].idx = 2;
         /* still we have to increase the number of rows */
         mat->nr++;
         for (k = 1; k < load; ++k) {
@@ -227,7 +229,7 @@ static int32_t select_spairs_by_minimal_degree(
 
     /* compute a truncated GB? Check maximal degree. */
     if (md->max_gb_degree < mdeg) {
-        return 1; 
+        return 1;
     }
 
     /* select pairs of this degree respecting maximal selection size mnsel */
@@ -260,7 +262,7 @@ static int32_t select_spairs_by_minimal_degree(
     /* printf("npd %d\n", npd); */
     /* sort_r(ps, (unsigned long)npd, sizeof(spair_t), spair_cmp, bht); */
     /* now do maximal selection if it applies */
-    
+
     /* if we stopped due to maximal selection size we still get the following
      * pairs of the same lcm in this matrix */
     if (npd > md->mnsel) {
@@ -273,8 +275,8 @@ static int32_t select_spairs_by_minimal_degree(
         nps = npd;
     }
     if (md->info_level > 1) {
-        printf("%3d  %6d %7d", mdeg, nps, psl->ld);
-        fflush(stdout);
+        fprintf(VERBSTREAM, "%3d  %6d %7d", mdeg, nps, psl->ld);
+        fflush(VERBSTREAM);
     }
     /* statistics */
     md->num_pairsred  +=  nps;
@@ -324,7 +326,7 @@ static int32_t select_spairs_by_minimal_degree(
          * lcm we add exactly one row to mat->rr */
         rrows[nrr]  = multiplied_poly_to_matrix_row(sht, bht, h, etmp, b);
         /* track trace information ? */
-        if (md->trace_level == LEARN_TRACER) { 
+        if (md->trace_level == LEARN_TRACER) {
            rrows[nrr][BINDEX]  = prev;
             if (bs->ht->eld == bs->ht->esz-1) {
                 enlarge_hash_table(bs->ht);
@@ -337,7 +339,7 @@ static int32_t select_spairs_by_minimal_degree(
         }
 
         /* mark lcm column as lead term column */
-        sht->hd[rrows[nrr++][OFFSET]].idx = 2; 
+        sht->hd[rrows[nrr++][OFFSET]].idx = 2;
         /* still we have to increase the number of rows */
         mat->nr++;
         for (k = 1; k < load; ++k) {
@@ -587,8 +589,8 @@ static void symbolic_preprocessing(
         mat->sz *=  2;
         mat->rr =   realloc(mat->rr, (unsigned long)mat->sz * sizeof(hm_t *));
         if (mat->rr == NULL) {
-            fprintf(stderr, "Allocating memory for matrix failed,\n");
-            fprintf(stderr, "segmentation fault will follow.\n");
+            fprintf(ERRSTREAM, "Allocating memory for matrix failed,\n");
+            fprintf(ERRSTREAM, "segmentation fault will follow.\n");
         }
     }
     for (; i < oesld; ++i) {
@@ -603,8 +605,8 @@ static void symbolic_preprocessing(
             mat->sz *=  2;
             mat->rr  =  realloc(mat->rr, (unsigned long)mat->sz * sizeof(hm_t *));
             if (mat->rr == NULL) {
-                fprintf(stderr, "Allocating memory for matrix failed,\n");
-                fprintf(stderr, "segmentation fault will follow.\n");
+                fprintf(ERRSTREAM, "Allocating memory for matrix failed,\n");
+                fprintf(ERRSTREAM, "segmentation fault will follow.\n");
             }
         }
         sht->hd[i].idx = 1;

--- a/src/usolve/debug.c
+++ b/src/usolve/debug.c
@@ -22,6 +22,7 @@
 //#include "utils.h"
 //#include "evaluate.h"
 //#include "print_usolve.h"
+#include "../msolve/streams.h"
 
 /* returns 1 if up has sign change over the interval encoded by root */
 /* return 0 otherwise */
@@ -29,30 +30,30 @@ static inline int check_sign_change(mpz_t *upoly, unsigned long int deg, interva
   if(root->isexact==1){
     mpz_t c;
     mpz_init_set(c, root->numer);
-    //  mpz_out_str(stderr, 10, c); puts("");
+    //  mpz_out_str(ERRSTREAM, 10, c); puts("");
     int s_down = sgn_mpz_poly_eval_at_point_2exp_naive(upoly, deg, &c, root->k);
     if(s_down!=0){
-      fprintf(stderr, "Negative (k): Not implemented yet ; skipped but useless with larger precision\n");
+      fprintf(ERRSTREAM, "Negative (k): Not implemented yet ; skipped but useless with larger precision\n");
       return 0; //    exit(1);
     }
     return 1;
   }
   if(root->k<=0){
-    fprintf(stderr, "Negative (k): Not implemented yet ; skipped but useless with larger precision\n");
+    fprintf(ERRSTREAM, "Negative (k): Not implemented yet ; skipped but useless with larger precision\n");
     return 1; //    exit(1);
   }
   mpz_t c;
   mpz_init_set(c, root->numer);
-  //  mpz_out_str(stderr, 10, c); puts("");
+  //  mpz_out_str(ERRSTREAM, 10, c); puts("");
   int s_down = sgn_mpz_poly_eval_at_point_2exp_naive(upoly, deg, &c, root->k);
   mpz_add_ui(c, c, 1);
-  //  mpz_out_str(stderr, 10, c); puts("");
+  //  mpz_out_str(ERRSTREAM, 10, c); puts("");
   int s_up = sgn_mpz_poly_eval_at_point_2exp_naive(upoly, deg, &c, root->k);
   mpz_clear(c);
   if(s_up*s_down<=0){
     return 1;
   }
-  fprintf(stderr, "\nBUG: no sign change\n");
+  fprintf(ERRSTREAM, "\nBUG: no sign change\n");
   return 0;
 }
 
@@ -62,9 +63,9 @@ static int check_all_sign_changes(mpz_t *upoly, unsigned long int deg, interval 
     if((root+i)->isexact==0){
       s = check_sign_change(upoly, deg, root+i);
       if(s==0){
-        fprintf(stderr, "Error occurred at root %lu\n", i);
-        USOLVEdisplay_roots(stderr, (root+i), 1);
-        fprintf(stderr, "\n");
+        fprintf(ERRSTREAM, "Error occurred at root %lu\n", i);
+        USOLVEdisplay_roots(ERRSTREAM, (root+i), 1);
+        fprintf(ERRSTREAM, "\n");
         exit(1);
       }
     }

--- a/src/usolve/evaluate.c
+++ b/src/usolve/evaluate.c
@@ -18,6 +18,8 @@
  * Christian Eder
  * Mohab Safey El Din */
 
+#include "../msolve/streams.h"
+
 /* val / 2^(deg) is up(1/2) */
 static inline void mpz_upoly_eval_onehalf(mpz_t *up, unsigned long int deg,
                                              mpz_t *val){
@@ -95,7 +97,7 @@ static inline int sgn_mpz_poly_eval_at_point_naive(mpz_t *upoly, unsigned long i
 
 /*
   Evaluates upol at c/2^k using a Horner scheme
-  In the end, one has 
+  In the end, one has
   val/2(k*deg)=up(c / 2^k) */
 void mpz_poly_eval_2exp_naive(mpz_t *upol,
                               long int deg,
@@ -124,7 +126,7 @@ void mpz_poly_eval_2exp_naive(mpz_t *upol,
 
 /*
   Evaluates upol at c/2^k using a Horner scheme
-  In the end, one has 
+  In the end, one has
   val/2(k*deg)=up(c / 2^k) */
 void mpz_poly_eval_2exp_naive2(mpz_t *upol,
                               long int deg,
@@ -174,10 +176,10 @@ int mpz_poly_eval_interval(mpz_t *up, const long int deg, const long k,
   mpz_init(s);
 
   if(mpz_sgn(a) != mpz_sgn(b) && mpz_sgn(a) != 0 && mpz_sgn(b) != 0){
-    fprintf(stderr, "Entries of mpz_poly_eval_interval are incorrect\n");
-    fprintf(stderr, "a and b should have same sign");
-    mpz_out_str(stderr, 10, a);
-    mpz_out_str(stderr, 10, b);
+    fprintf(ERRSTREAM, "Entries of mpz_poly_eval_interval are incorrect\n");
+    fprintf(ERRSTREAM, "a and b should have same sign");
+    mpz_out_str(ERRSTREAM, 10, a);
+    mpz_out_str(ERRSTREAM, 10, b);
     mpz_clear(s);
     exit(1);
   }
@@ -205,7 +207,7 @@ int mpz_poly_eval_interval(mpz_t *up, const long int deg, const long k,
       }
 
       if(mpz_cmp(val_do, val_up) > 0){
-        fprintf(stderr, "BUG ici (den_do > den_up)\n");
+        fprintf(ERRSTREAM, "BUG ici (den_do > den_up)\n");
         exit(1);
       }
 
@@ -237,9 +239,9 @@ int mpz_poly_eval_interval(mpz_t *up, const long int deg, const long k,
       }
 
       if(mpz_cmp(val_do, val_up) > 0){
-        fprintf(stderr, "BUG ici2 (val_do > val_up)\n");
-        fprintf(stderr, "=> sign of val_do = %d\n", mpz_sgn(val_do));
-        fprintf(stderr, "=> sign of val_up = %d\n", mpz_sgn(val_up));
+        fprintf(ERRSTREAM, "BUG ici2 (val_do > val_up)\n");
+        fprintf(ERRSTREAM, "=> sign of val_do = %d\n", mpz_sgn(val_do));
+        fprintf(ERRSTREAM, "=> sign of val_up = %d\n", mpz_sgn(val_up));
         exit(1);
       }
     }
@@ -356,9 +358,9 @@ int lazy_mpz_poly_eval_interval(mpz_t *up, const long int deg,
     }
 
     if(mpz_cmp(fdo, fup) > 0){
-      fprintf(stderr, "BUG in preprocess eval (fdo > fup)\n");
-      mpz_out_str(stderr, 10, fdo); fprintf(stderr, "\n");
-      mpz_out_str(stderr, 10, fup); fprintf(stderr, "\n");
+      fprintf(ERRSTREAM, "BUG in preprocess eval (fdo > fup)\n");
+      mpz_out_str(ERRSTREAM, 10, fdo); fprintf(ERRSTREAM, "\n");
+      mpz_out_str(ERRSTREAM, 10, fup); fprintf(ERRSTREAM, "\n");
       exit(1);
     }
 
@@ -392,17 +394,17 @@ int lazy_mpz_poly_eval_interval(mpz_t *up, const long int deg,
 
 
     if(mpz_cmp(fdo, fup) > 0){
-      fprintf(stderr, "BUG in preprocess2 eval (fdo > fup)\n");
-      mpz_out_str(stderr, 10, xdo[j*b]); fprintf(stderr, "\n");
-      mpz_out_str(stderr, 10, xup[j*b]); fprintf(stderr, "\n");
-      fprintf(stderr, "cmp = %d\n", mpz_cmp(xdo[j*b], xup[j*b]));
+      fprintf(ERRSTREAM, "BUG in preprocess2 eval (fdo > fup)\n");
+      mpz_out_str(ERRSTREAM, 10, xdo[j*b]); fprintf(ERRSTREAM, "\n");
+      mpz_out_str(ERRSTREAM, 10, xup[j*b]); fprintf(ERRSTREAM, "\n");
+      fprintf(ERRSTREAM, "cmp = %d\n", mpz_cmp(xdo[j*b], xup[j*b]));
       exit(1);
     }
 
     if(mpz_cmp(val_do, val_up) > 0){
-      fprintf(stderr, "BUG in eval (val_do > val_up)\n");
-      mpz_out_str(stderr, 10, val_do); fprintf(stderr, "\n");
-      mpz_out_str(stderr, 10, val_up); fprintf(stderr, "\n");
+      fprintf(ERRSTREAM, "BUG in eval (val_do > val_up)\n");
+      mpz_out_str(ERRSTREAM, 10, val_do); fprintf(ERRSTREAM, "\n");
+      mpz_out_str(ERRSTREAM, 10, val_up); fprintf(ERRSTREAM, "\n");
       exit(1);
     }
   }
@@ -431,16 +433,16 @@ int lazy_mpz_poly_eval_interval(mpz_t *up, const long int deg,
     }
 
     if(mpz_cmp(fdo, fup) > 0){
-      fprintf(stderr, "BUG in preprocess3 init eval (fdo > fup)\n");
+      fprintf(ERRSTREAM, "BUG in preprocess3 init eval (fdo > fup)\n");
       exit(1);
     }
 
     if(mpz_cmp(val_do, val_up) > 0){
-      fprintf(stderr, "BUG in eval (val_do > val_up)\n");
+      fprintf(ERRSTREAM, "BUG in eval (val_do > val_up)\n");
       exit(1);
     }
     if(mpz_cmp(fdo, fup) > 0){
-      fprintf(stderr, "BUG in preprocess3 init0 eval (fdo > fup)\n");
+      fprintf(ERRSTREAM, "BUG in preprocess3 init0 eval (fdo > fup)\n");
       exit(1);
     }
 

--- a/src/usolve/refine.c
+++ b/src/usolve/refine.c
@@ -48,9 +48,9 @@ static long long int index_linearinterp(mpz_t *vala, mpz_t *valb, mpz_t *q,
   long int sizeq = ilog2_mpz(*q);
   if((long unsigned int)sizeq >= 8 * sizeof(long long int)){
     if(sizeq > logN){
-      fprintf(stderr,"Valeur de q = "); mpz_out_str(stderr, 10, *q);puts("");
-      fprintf(stderr, "Valeur de Nlog = %lld\n", logN);
-      fprintf(stderr, "ilog2(q) = %ld\n", sizeq);
+      fprintf(ERRSTREAM,"Valeur de q = "); mpz_out_str(ERRSTREAM, 10, *q);puts("");
+      fprintf(ERRSTREAM, "Valeur de Nlog = %lld\n", logN);
+      fprintf(ERRSTREAM, "ilog2(q) = %ld\n", sizeq);
       return -2;
     }
     return -1;
@@ -364,7 +364,7 @@ static void refine_root_by_N_positive_k(mpz_t *upol, unsigned long int *deg_ptr,
       while(right_interval_2exp(upol, deg_ptr, rt, x, b,
                                 vala, valb, q, newk)==0 && index <= maxindex){
         if(verbose>0){
-          fprintf(stdout, "->");
+          fprintf(VERBSTREAM, "->");
         }
         index++;
       }
@@ -406,7 +406,7 @@ static void refine_root_by_N_positive_k(mpz_t *upol, unsigned long int *deg_ptr,
       while(left_interval_2exp(upol, deg_ptr, rt,
                                x, b, vala, valb, q, newk) == 0){
         if(verbose>0){
-          fprintf(stdout, "<-");
+          fprintf(VERBSTREAM, "<-");
         }
       }
     }
@@ -529,7 +529,7 @@ static void refine_root_by_N_negative_k(mpz_t *upol, unsigned long int *deg_ptr,
       while(right_interval(upol, deg_ptr, rt, x, b,
                            vala, valb, q, Nlog, k, newk) == 0){
         if(verbose>0){
-          fprintf(stdout, "|->");
+          fprintf(VERBSTREAM, "|->");
         }
       }
     }
@@ -587,7 +587,7 @@ static void refine_root_by_N_negative_k(mpz_t *upol, unsigned long int *deg_ptr,
       while(left_interval(upol, deg_ptr, rt, x, b,
                           vala, valb, q, Nlog, k, newk) == 0){
         if(verbose>0){
-          fprintf(stdout, "<-|");
+          fprintf(VERBSTREAM, "<-|");
         }
       }
     }
@@ -653,7 +653,7 @@ void refine_QIR_positive_root(mpz_t *upol, unsigned long int *deg_ptr,
     if(rt->isexact==1) return;
 
     if(mpz_sgn(tab[0]) == mpz_sgn(tab[1])) {
-      fprintf(stderr, "BUG in refine_QIR_positive_root");
+      fprintf(ERRSTREAM, "BUG in refine_QIR_positive_root");
       exit(1);
     }
     if(success == 1){
@@ -777,7 +777,7 @@ void refine_QIR_roots(mpz_t *upol, unsigned long int *deg, interval *roots,
 
     interval *rt = roots + i;
 
-    /* display_root(stderr, rt); */
+    /* display_root(ERRSTREAM, rt); */
 
     if(rt->k > 0){
       if(rt->isexact!=1){
@@ -803,13 +803,13 @@ void refine_QIR_roots(mpz_t *upol, unsigned long int *deg, interval *roots,
     if(pos_rt->isexact==0){
       get_values_at_bounds(upol, *deg, pos_rt, tab);
       if(mpz_sgn(tab[0])==0 || mpz_sgn(tab[1])==0){
-        fprintf(stderr, "Error in refinement (neg. roots): these values should not be zero\n");
+        fprintf(ERRSTREAM, "Error in refinement (neg. roots): these values should not be zero\n");
         exit(1);
       }
       refine_QIR_positive_root(upol, deg, pos_rt, tab, prec, verbose);
 
       if(mpz_sgn(tab[0])==mpz_sgn(tab[1])){
-        fprintf(stderr, "BUG in refinement (sgn tab[0]==sgn tab[1]) for neg. roots");
+        fprintf(ERRSTREAM, "BUG in refinement (sgn tab[0]==sgn tab[1]) for neg. roots");
         exit(1);
       }
     }
@@ -840,7 +840,7 @@ void refine_QIR_roots(mpz_t *upol, unsigned long int *deg, interval *roots,
       refine_time = realtime();
       e_time = 0;
       if(verbose>0){
-        fprintf(stdout, "{%.2f%s}", ((double)i / nb) * 100, "%");
+        fprintf(VERBSTREAM, "{%.2f%s}", ((double)i / nb) * 100, "%");
       }
     }
   }
@@ -862,12 +862,12 @@ void refine_QIR_roots(mpz_t *upol, unsigned long int *deg, interval *roots,
     if(rt->isexact==0){
       get_values_at_bounds(upol, *deg, rt, tab);
       if(mpz_sgn(tab[1])==0 || mpz_sgn(tab[0])==0){
-        fprintf(stderr, "Error in refinement (pos. roots): these values should not be zero\n");
+        fprintf(ERRSTREAM, "Error in refinement (pos. roots): these values should not be zero\n");
         exit(1);
       }
       refine_QIR_positive_root(upol, deg, rt, tab, prec, verbose);
       if(mpz_sgn(tab[0])==mpz_sgn(tab[1])){
-        fprintf(stderr,"BUG in refinement (sgn tab[0]=sgn tab[1] for pos. roots)");
+        fprintf(ERRSTREAM,"BUG in refinement (sgn tab[0]=sgn tab[1] for pos. roots)");
         exit(1);
       }
       if(rt->isexact==1){
@@ -882,13 +882,13 @@ void refine_QIR_roots(mpz_t *upol, unsigned long int *deg, interval *roots,
       refine_time = realtime();
       e_time = 0;
       if(verbose>0){
-        fprintf(stdout, "{%.2f%s}", ((double)(i) / nb) * 100, "%");
+        fprintf(VERBSTREAM, "{%.2f%s}", ((double)(i) / nb) * 100, "%");
       }
     }
 
   }
   if(verbose>0){
-    fprintf(stdout, "\n");
+    fprintf(VERBSTREAM, "\n");
   }
   for(i = 0; i < 8; i++){
     mpz_clear(tab[i]);
@@ -933,7 +933,7 @@ void refine_QIR_roots_adaptative(mpz_t *upol, unsigned long int *deg, interval *
 
     interval *rt = roots + i;
 
-    /* display_root(stderr, rt); */
+    /* display_root(ERRSTREAM, rt); */
 
     if(rt->k > 0){
       if(rt->isexact!=1){
@@ -959,18 +959,18 @@ void refine_QIR_roots_adaptative(mpz_t *upol, unsigned long int *deg, interval *
     if(pos_rt->isexact==0){
       get_values_at_bounds(upol, *deg, pos_rt, tab);
       if(mpz_sgn(tab[0])==0 || mpz_sgn(tab[1])==0){
-        fprintf(stderr, "Error in refinement (neg. roots): these values should not be zero\n");
+        fprintf(ERRSTREAM, "Error in refinement (neg. roots): these values should not be zero\n");
         exit(1);
       }
       long d = 1 + ilog2_mpz(pos_rt->numer) - rt->k;
 
-      /* fprintf(stderr, "[%d, %ld]", prec, */
+      /* fprintf(ERRSTREAM, "[%d, %ld]", prec, */
       /*         prec + ((*deg) * MAX(0, d)) / 32); */
       refine_QIR_positive_root(upol, deg, pos_rt, tab,
                                prec + (((*deg)-1) * MAX(0, d)) / 32, verbose);
 
       if(mpz_sgn(tab[0])==mpz_sgn(tab[1])){
-        fprintf(stderr, "BUG in refinement (sgn tab[0]==sgn tab[1]) for neg. roots");
+        fprintf(ERRSTREAM, "BUG in refinement (sgn tab[0]==sgn tab[1]) for neg. roots");
         exit(1);
       }
     }
@@ -1001,7 +1001,7 @@ void refine_QIR_roots_adaptative(mpz_t *upol, unsigned long int *deg, interval *
       refine_time = realtime();
       e_time = 0;
       if(verbose>0){
-        fprintf(stdout, "{%.2f%s}", ((double)i / nb) * 100, "%");
+        fprintf(VERBSTREAM, "{%.2f%s}", ((double)i / nb) * 100, "%");
       }
     }
   }
@@ -1023,16 +1023,16 @@ void refine_QIR_roots_adaptative(mpz_t *upol, unsigned long int *deg, interval *
     if(rt->isexact==0){
       get_values_at_bounds(upol, *deg, rt, tab);
       if(mpz_sgn(tab[1])==0 || mpz_sgn(tab[0])==0){
-        fprintf(stderr, "Error in refinement (pos. roots): these values should not be zero\n");
+        fprintf(ERRSTREAM, "Error in refinement (pos. roots): these values should not be zero\n");
         exit(1);
       }
       long d = 1 + ilog2_mpz(rt->numer) - rt->k;
 
-      /* fprintf(stderr, "[%d, %ld]", prec, prec + ((*deg) * MAX(0, 1 + d)) / 32); */
+      /* fprintf(ERRSTREAM, "[%d, %ld]", prec, prec + ((*deg) * MAX(0, 1 + d)) / 32); */
       refine_QIR_positive_root(upol, deg, rt, tab,
                                prec + (((*deg) - 1) * MAX(0, 1 + d)) / 32, verbose);
       if(mpz_sgn(tab[0])==mpz_sgn(tab[1])){
-        fprintf(stderr,"BUG in refinement (sgn tab[0]=sgn tab[1] for pos. roots)");
+        fprintf(ERRSTREAM,"BUG in refinement (sgn tab[0]=sgn tab[1] for pos. roots)");
         exit(1);
       }
       if(rt->isexact==1){
@@ -1047,13 +1047,13 @@ void refine_QIR_roots_adaptative(mpz_t *upol, unsigned long int *deg, interval *
       refine_time = realtime();
       e_time = 0;
       if(verbose>0){
-        fprintf(stdout, "{%.2f%s}", ((double)(i) / nb) * 100, "%");
+        fprintf(VERBSTREAM, "{%.2f%s}", ((double)(i) / nb) * 100, "%");
       }
     }
 
   }
   if(verbose>0){
-    fprintf(stdout, "\n");
+    fprintf(VERBSTREAM, "\n");
   }
   for(i = 0; i < 8; i++){
     mpz_clear(tab[i]);

--- a/src/usolve/tests.c
+++ b/src/usolve/tests.c
@@ -309,14 +309,14 @@ void multi_mod_taylor_shift(mpz_t *pol, unsigned long int deg,
                             int nthreads){
 
   unsigned long int nbits = USOLVEmpz_poly_max_bsize_coeffs(pol, deg);
-  fprintf(stderr, "nbits = %lu\n", nbits);
+  fprintf(ERRSTREAM, "nbits = %lu\n", nbits);
   nbits = nbits + deg + 1 + LOG2(deg + 1);
-  fprintf(stderr, "nbits = %lu\n", nbits);
+  fprintf(ERRSTREAM, "nbits = %lu\n", nbits);
 
   /* gets primes between 2^63 and 2^64 */
   unsigned long int nprimes = (nbits + (BITSPRIME - 1) - 1) / (BITSPRIME - 1);
   mp_ptr primes = malloc(sizeof(mp_limb_t) * nprimes);
-  fprintf(stderr, "%lu\n", UWORD(1) << (BITSPRIME - 1));
+  fprintf(ERRSTREAM, "%lu\n", UWORD(1) << (BITSPRIME - 1));
   primes[0] = n_nextprime(UWORD(1) << (BITSPRIME - 1), 1);
   for (unsigned long int i = 1; i < nprimes; i++)
     primes[i] = n_nextprime(primes[i-1], 1);
@@ -327,7 +327,7 @@ void multi_mod_taylor_shift(mpz_t *pol, unsigned long int deg,
     residues[i] = malloc(sizeof(mp_limb_t) * (deg + 1));
   }
 
-  fprintf(stderr, "nprimes = %lu\n", nprimes);
+  fprintf(ERRSTREAM, "nprimes = %lu\n", nprimes);
   //allocates space for shiftedpowers of X
   unsigned long int nblocks = 1<<LOG2(deg/pwx);
   unsigned long int npowers=LOG2(nblocks);
@@ -343,7 +343,7 @@ void multi_mod_taylor_shift(mpz_t *pol, unsigned long int deg,
       pX = 2 * pX;
     }
   }
-  fprintf(stderr, "Modular residues (shifted powers of X) obtained\n");
+  fprintf(ERRSTREAM, "Modular residues (shifted powers of X) obtained\n");
   mp_ptr tmp;
 
   fmpz_comb_t comb;
@@ -355,7 +355,7 @@ void multi_mod_taylor_shift(mpz_t *pol, unsigned long int deg,
 
   mp_ptr tmp_pol = malloc(sizeof(mp_limb_t) * (deg + 1));
   unsigned long int length = deg + 1;
-  fprintf(stderr, "Allocation done\n");
+  fprintf(ERRSTREAM, "Allocation done\n");
   double e = realtime();
   for(unsigned long int j = 0; j < length; j++){
     //    fmpz_multi_mod_ui(tmp, pol + i, comb, comb_temp);
@@ -364,7 +364,7 @@ void multi_mod_taylor_shift(mpz_t *pol, unsigned long int deg,
       //      residues[i][j] = mpz_fdiv_ui(pol[j], primes[i]);
       residues[i][j] = mpz_fdiv_ui(pol[j], primes[i]);
   }
-  fprintf(stderr, "Residues loaded (%f sec)\n", realtime() - e);
+  fprintf(ERRSTREAM, "Residues loaded (%f sec)\n", realtime() - e);
   for(unsigned long int i = 0; i < nprimes; i++){
     nmod_t mod;
     mp_limb_t p;
@@ -373,7 +373,7 @@ void multi_mod_taylor_shift(mpz_t *pol, unsigned long int deg,
     nmod_init(&mod, p);
     nmod_upoly_taylor_shift(residues[i], deg, tmp_pol, residues_shift_pwx[i], pwx, mod);
   }
-  fprintf(stderr, "Time multimod = %f\n", realtime() - e);
+  fprintf(ERRSTREAM, "Time multimod = %f\n", realtime() - e);
   free(tmp);
   for(unsigned long int i = 0; i < nprimes; i++){
     free(residues[i]);
@@ -411,18 +411,18 @@ void tbr_taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **po
   long int nbits = USOLVEmpz_poly_max_bsize_coeffs(pol, deg);
   //  mpz_poly_print_maple(pol, deg);
   //  long int sb = 2 * nbits / (nthreads * deg);
-  //  fprintf(stderr, "[sb = %ld]\n", sb);
+  //  fprintf(ERRSTREAM, "[sb = %ld]\n", sb);
   if(nthreads >= 1){
-    //    fprintf(stderr, "New algo starts\n");
+    //    fprintf(ERRSTREAM, "New algo starts\n");
     split_coeffs_poly(pols, pol, deg, nbits, nthreads);
     //double e = realtime();
 #pragma omp parallel for num_threads(nthreads)
     for(int j = 0; j < nthreads; j++){
-      //      fprintf(stderr, "bs = %ld\n", mpz_poly_max_bsize_coeffs(pols[j], deg));
+      //      fprintf(ERRSTREAM, "bs = %ld\n", mpz_poly_max_bsize_coeffs(pols[j], deg));
       //      mpz_poly_print_maple(pols[j], deg);
       taylorshift1_dac(pols[j], deg, tmp[j], shift_pwx, pwx, 0);
     }
-    //    fprintf(stderr, "time %f\n", realtime() - e);
+    //    fprintf(ERRSTREAM, "time %f\n", realtime() - e);
     //    e = realtime();
 #pragma omp parallel for num_threads(nthreads)
     for(int j = 0; j < nthreads; j++){
@@ -431,7 +431,7 @@ void tbr_taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **po
         mpz_mul_2exp(pols[j][i], pols[j][i], trunc);
       }
     }
-    //    fprintf(stderr, "Rescaling done (time = %f)\n", realtime() - e);
+    //    fprintf(ERRSTREAM, "Rescaling done (time = %f)\n", realtime() - e);
 #pragma omp parallel for num_threads(nthreads)
     for(unsigned long int i = 0; i <= deg; i++){
       mpz_set_ui(pol[i], 0);
@@ -484,7 +484,7 @@ void taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **pols,
   if(nthreads >= 1 && nblocks > 0){
 
     if(nblocks <= nthreads){
-      fprintf(stderr, "nblocks (%ld) <= nthreads (%d)\n", nblocks, nthreads);
+      fprintf(ERRSTREAM, "nblocks (%ld) <= nthreads (%d)\n", nblocks, nthreads);
       //      long int nt = nthreads / nblocks;
       //pol = pols[0] + 2^(2*deg) * pols[1] + 2^(4*deg) * pols[2] + 2^(6*deg) *pols[3] +...+2^(nblocks*2*deg)*pols[nblocks]
       decompose_bits_poly(pols, pol, deg, cutoff, nbits, nblocks);
@@ -496,13 +496,13 @@ void taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **pols,
         //#pragma omp parallel for num_threads(nthreads) schedule(dynamic)
 #pragma omp parallel for schedule(dynamic)
       for(int j = 0; j < nblocks; j++){
-      //        fprintf(stderr, "bs = %ld\n", mpz_poly_max_bsize_coeffs(pols[j], deg));
+      //        fprintf(ERRSTREAM, "bs = %ld\n", mpz_poly_max_bsize_coeffs(pols[j], deg));
         mpz_t *local_pol = pols[j];
         mpz_t *local_tmp = tmp[j];
         taylorshift1_dac(local_pol, deg, local_tmp, shift_pwx, pwx, 1);
       }
       }
-      //      fprintf(stderr, "time %f\n", realtime() - e);
+      //      fprintf(ERRSTREAM, "time %f\n", realtime() - e);
       //      mpz_poly_print_maple(pols[0], deg);
       //      e = realtime();
       for(long int j = nblocks-1; j >=0; j--){
@@ -527,7 +527,7 @@ void taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **pols,
       return;
     }
     else{//nblocks > nthreads
-      fprintf(stderr, "nblocks (%ld) > nthreads (%d)\n", nblocks, nthreads);
+      fprintf(ERRSTREAM, "nblocks (%ld) > nthreads (%d)\n", nblocks, nthreads);
       //nblocks = nbits / cutoff
       long int q = nblocks / nthreads ;//pb quand nthreads = 1 (doit prendre q+1)
       if(nthreads==1){
@@ -565,7 +565,7 @@ void taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **pols,
         nbits -= cutoff * nthreads;
         q--;
       }
-      //      fprintf(stderr, "time = %f\n", e);
+      //      fprintf(ERRSTREAM, "time = %f\n", e);
 
       long rth = nblocks % nthreads + 1;
 
@@ -579,7 +579,7 @@ void taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **pols,
       tmp_e = realtime();
       decompose_bits_poly(pols, pol, deg, cutoff, nbits, rth);
       e += (realtime() - tmp_e);
-      //      fprintf(stderr, "time in decompose_bits_poly = %f\n", e);
+      //      fprintf(ERRSTREAM, "time in decompose_bits_poly = %f\n", e);
       //      e = realtime();
       //#pragma omp parallel for num_threads(rth)
       for(int j = 0; j < rth; j++){
@@ -612,8 +612,8 @@ void taylor_shift(mpz_t *pol, unsigned long int deg, mpz_t **tmp, mpz_t **pols,
 
 int main(int argc, char **argv){
   if(argc!=5){
-    fprintf(stderr, "Runs taylor shifts and measures timings\n");
-    fprintf(stderr, "Usage is %s <degree> <nbits> <nthreads> <nloops>\n", argv[0]);
+    fprintf(ERRSTREAM, "Runs taylor shifts and measures timings\n");
+    fprintf(ERRSTREAM, "Usage is %s <degree> <nbits> <nthreads> <nloops>\n", argv[0]);
     exit(1);
   }
   unsigned long int deg = atoi(argv[1]);
@@ -631,12 +631,12 @@ int main(int argc, char **argv){
     mpz_init2(tmpol[i], deg + nbits);
   }
   usolve_flags *flags = (usolve_flags*)(malloc(sizeof(usolve_flags)));
-  fprintf(stderr, "Starting initialization of data\n");
+  fprintf(ERRSTREAM, "Starting initialization of data\n");
   double t = realtime();
   initialize_flags(flags);
 
   initialize_heap_flags(flags, deg);
-  fprintf(stderr, "Time for initialization = %f\n", realtime()-t);
+  fprintf(ERRSTREAM, "Time for initialization = %f\n", realtime()-t);
   mpz_random_dense_poly(pol1, deg, nbits);
   //  USOLVEmpz_poly_print_maple(pol1, deg);
 
@@ -645,7 +645,7 @@ int main(int argc, char **argv){
     mpz_set(pol3[i], pol1[i]);
   }
   int nloops = atoi(argv[4]);
-  fprintf(stderr, "nloops = %d\n\n", nloops);
+  fprintf(ERRSTREAM, "nloops = %d\n\n", nloops);
 
   double e_time = realtime();
 
@@ -656,11 +656,11 @@ int main(int argc, char **argv){
   e_time =  realtime();
   for(int i = 0; i < nloops; i++)
     taylorshift1_dac(pol1, deg, tmpol, flags->shift_pwx, flags->pwx, nthreads);
-  fprintf(stdout, "Elapsed time %f (Taylor shift Usolve nthreads = %d)\n", realtime() - e_time, nthreads);
+  fprintf(VERBSTREAM, "Elapsed time %f (Taylor shift Usolve nthreads = %d)\n", realtime() - e_time, nthreads);
 
   mpz_t **tmp = malloc(sizeof(mpz_t *) * (nthreads + 1));
   mpz_t **pols = malloc(sizeof(mpz_t *) * nthreads);
-  fprintf(stderr, "Allocation starts\n");
+  fprintf(ERRSTREAM, "Allocation starts\n");
   for(int i = 0; i <= nthreads; i++){
     tmp[i] = (mpz_t *)malloc((deg + 1) * sizeof(mpz_t));
     for(unsigned long int j = 0; j <= deg; j++){
@@ -673,18 +673,18 @@ int main(int argc, char **argv){
       mpz_init2(pols[i][j], 2 * deg);
     }
   }
-  fprintf(stderr, "Allocation done\n\n");
+  fprintf(ERRSTREAM, "Allocation done\n\n");
 
   e_time = realtime();
   for(int i=0; i < nloops; i++)
     tbr_taylor_shift(pol2, deg, tmp, pols, flags->shift_pwx, flags->pwx, nthreads);
-  fprintf(stdout, "Elapsed time (New TBR_Taylor shift with nthreads = %d) %f\n\n", nthreads, realtime() - e_time);
+  fprintf(VERBSTREAM, "Elapsed time (New TBR_Taylor shift with nthreads = %d) %f\n\n", nthreads, realtime() - e_time);
 
 
   e_time = realtime();
   for(int i=0; i < nloops; i++)
     taylor_shift(pol3, deg, tmp, pols, flags->shift_pwx, flags->pwx, nthreads);
-  fprintf(stdout, "Elapsed time (New Taylor shift not in Usolve yet with nthreads = %d) %f\n\n", nthreads, realtime() - e_time);
+  fprintf(VERBSTREAM, "Elapsed time (New Taylor shift not in Usolve yet with nthreads = %d) %f\n\n", nthreads, realtime() - e_time);
 
   for(int i = 0; i < nthreads; i++){
     for(unsigned long int j = 0; j <= deg; j++){
@@ -699,11 +699,11 @@ int main(int argc, char **argv){
 
   for(unsigned long i=0; i <= deg; i++){
     if(mpz_cmp(pol1[i], pol2[i])!=0){
-      fprintf(stderr, "BUG in TBR\n\n");
+      fprintf(ERRSTREAM, "BUG in TBR\n\n");
       return 1;
     }
     if(mpz_cmp(pol1[i], pol3[i])!=0){
-      fprintf(stderr, "BUG in TL\n\n");
+      fprintf(ERRSTREAM, "BUG in TL\n\n");
       return 1;
     }
   }

--- a/src/usolve/univmultiply.c
+++ b/src/usolve/univmultiply.c
@@ -24,6 +24,8 @@
 #include<omp.h>
 #endif
 
+#include "../msolve/streams.h"
+
 #define USEFLINT 1
 
 #ifdef USEFLINT
@@ -119,7 +121,7 @@ static void mpz_poly_mul(mpz_t *res,
   fmpz_poly_clear(pol2_fmpz_poly);
 
 #else
-  fprintf(stderr, "FLINT is missing for univariate polynomial multiplication\n");
+  fprintf(ERRSTREAM, "FLINT is missing for univariate polynomial multiplication\n");
   exit(1);
 #endif
 }

--- a/src/usolve/usolve.c
+++ b/src/usolve/usolve.c
@@ -37,6 +37,7 @@
 #include "flint/fmpz_poly.h"
 
 #include "../msolve/msolve-data.h"
+#include "../msolve/streams.h"
 
 #define THRESHOLDSHIFT 256
 #define POWER_HACK 1
@@ -292,7 +293,7 @@ static void is_zero_root(mpz_t *upol, mpz_t c, long k,
     }
 
     if(i >= 2){
-      fprintf(stderr, "error: the polynomial is not square-free\n");
+      fprintf(ERRSTREAM, "error: the polynomial is not square-free\n");
       exit(1);
     }
 
@@ -404,7 +405,7 @@ static long int manage_root_at_one_half(mpz_t *upol,
 
     flags->cur_deg = (*deg);
     if(sh == 0){
-      fprintf(stderr, "Input polynomial is not square-free\n");
+      fprintf(ERRSTREAM, "Input polynomial is not square-free\n");
       exit(1);
     }
 
@@ -464,19 +465,19 @@ static long nb_0_case_in_bisection_rec(const mpz_t c, const long k,
     }
 
     if(flags->verbose >= 1){
-      fprintf(stdout,"+");
-      if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+      fprintf(VERBSTREAM,"+");
+      if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
     }
   }
   if(flags->verbose >= 1){
-    fprintf(stdout,"!");
+    fprintf(VERBSTREAM,"!");
   }
   mpz_clear(tmp);
   return k;
 }
 
 
-static long nb_1_case_in_bisection_rec(mpz_t c, const long k, 
+static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
                                        mpz_t tmp,
                                        interval *roots, unsigned long int *nbr,
                                        usolve_flags *flags, const int is_half_root,
@@ -491,8 +492,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
         (*nbr) ++;
 
         if(flags->verbose >= 1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots == 1 && (*nbr)>0){
           mpz_clear(tmp);
@@ -505,8 +506,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
         (*nbr)++;
 
         if(flags->verbose >= 1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
       }
       else{
@@ -518,8 +519,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
                    flags->bound_pos, flags->bound_neg, flags->sign);
         (*nbr)++;
         if(flags->verbose >= 1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots==1 && (*nbr)>0){
           mpz_clear(tmp);
@@ -531,8 +532,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
                      flags->bound_pos, flags->bound_neg, flags->sign);
           (*nbr)++;
           if(flags->verbose >= 1){
-            fprintf(stdout,"+");
-            if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+            fprintf(VERBSTREAM,"+");
+            if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
           }
         }
         else{
@@ -542,8 +543,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
                      flags->bound_pos, flags->bound_neg, flags->sign);
           (*nbr) ++;
           if(flags->verbose>=1){
-            fprintf(stdout,"+");
-            if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+            fprintf(VERBSTREAM,"+");
+            if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
           }
           if(flags->hasrealroots == 1 && (*nbr)>0){
             mpz_clear(tmp);
@@ -558,8 +559,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
                    flags->bound_pos, flags->bound_neg, flags->sign);
         (*nbr)++;
         if(flags->verbose>=1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots==1 && (*nbr)>0){
           mpz_clear(tmp);
@@ -573,8 +574,8 @@ static long nb_1_case_in_bisection_rec(mpz_t c, const long k,
                    flags->bound_pos, flags->bound_neg, flags->sign);
         (*nbr)++;
         if(flags->verbose >= 1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots == 1 && (*nbr)>0){
           mpz_clear(tmp);
@@ -604,8 +605,8 @@ static long nb_2_case_in_bisection_rec(mpz_t c, const long k,
       (*nbr)++;
 
       if(flags->verbose>=1){
-        fprintf(stdout,"+");
-        if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+        fprintf(VERBSTREAM,"+");
+        if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
       }
       if(flags->hasrealroots==1 && (*nbr)>0){
         mpz_clear(tmp);
@@ -618,8 +619,8 @@ static long nb_2_case_in_bisection_rec(mpz_t c, const long k,
                    flags->bound_pos, flags->bound_neg, flags->sign);
         (*nbr)++;
         if(flags->verbose >= 1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots==1 && (*nbr)>0){
           mpz_clear(tmp);
@@ -631,8 +632,8 @@ static long nb_2_case_in_bisection_rec(mpz_t c, const long k,
                    flags->bound_pos, flags->bound_neg, flags->sign);
         (*nbr) ++;
         if(flags->verbose >= 1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots == 1 && (*nbr) > 0){
           mpz_clear(tmp);
@@ -647,8 +648,8 @@ static long nb_2_case_in_bisection_rec(mpz_t c, const long k,
                    flags->bound_pos, flags->bound_neg, flags->sign);
         (*nbr) ++;
         if(flags->verbose>=1){
-          fprintf(stdout,"+");
-          if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+          fprintf(VERBSTREAM,"+");
+          if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
         }
         if(flags->hasrealroots==1 && (*nbr)>0){
           mpz_clear(tmp);
@@ -658,7 +659,7 @@ static long nb_2_case_in_bisection_rec(mpz_t c, const long k,
       /* if(flags->debug==1){ */
       /*   long bo=mpz_sgn(upoly[0]); */
       /*   long to=mpz_poly_sign_at_one(upol, (*deg), flags->Values); */
-      /*   fprintf(stderr,"[d:%ld, %ld, %ld]",bo,shalf,to); */
+      /*   fprintf(ERRSTREAM,"[d:%ld, %ld, %ld]",bo,shalf,to); */
       /* } */
       mpz_clear(tmp);
       return k;
@@ -680,7 +681,7 @@ static long nb_default_case_in_bisection_rec(mpz_t *upol, unsigned long int *deg
   int branch_right = 1;
 
   if(flags->verbose>=1){
-    fprintf(stdout,"-");
+    fprintf(VERBSTREAM,"-");
   }
   mpz_mul_2exp(tmp, tmp, 1);
   USOLVEmpz_poly_rescale_normalize_2exp_th(upol, -1,
@@ -691,7 +692,7 @@ static long nb_default_case_in_bisection_rec(mpz_t *upol, unsigned long int *deg
                          flags, tmp_half);
   }
   else{
-    if(flags->verbose >= 1) fprintf(stdout, "!");
+    if(flags->verbose >= 1) fprintf(VERBSTREAM, "!");
     oldk = k + 1;
   }
 
@@ -707,8 +708,8 @@ static long nb_default_case_in_bisection_rec(mpz_t *upol, unsigned long int *deg
                flags->sign);
     (*nbr)++;
     if(flags->verbose>=1){
-      fprintf(stdout,"+");
-      if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+      fprintf(VERBSTREAM,"+");
+      if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
     }
     if(flags->hasrealroots == 1 && (*nbr)>0){
       mpz_clear(tmp);
@@ -723,7 +724,7 @@ static long nb_default_case_in_bisection_rec(mpz_t *upol, unsigned long int *deg
 
   e_time =  realtime();
   if(flags->verbose>=1){
-    fprintf(stdout,"*");
+    fprintf(VERBSTREAM,"*");
   }
   if(flags->classical_algo==1){
     taylorshift1_naive(upol, *deg);
@@ -747,7 +748,7 @@ static long nb_default_case_in_bisection_rec(mpz_t *upol, unsigned long int *deg
   else{
     oldk = k + 1;
     nb = mpz_poly_sgn_variations_coeffs_is_zero(upol, (*deg));
-    if(flags->verbose >= 1) fprintf(stdout, "!");
+    if(flags->verbose >= 1) fprintf(VERBSTREAM, "!");
     if(nb == 0) oldk = -1;
   }
 
@@ -775,7 +776,7 @@ static long bisection_rec(mpz_t *upol, unsigned long *deg,
                           usolve_flags *flags,
                           mpz_t tmp_half){
 
-  /* display_roots_system(stderr, roots, *nbr); */
+  /* display_roots_system(ERRSTREAM, roots, *nbr); */
   long nb;
   long shalf;
   long bsgn = 0;
@@ -786,14 +787,14 @@ static long bisection_rec(mpz_t *upol, unsigned long *deg,
   (flags->node_looked)++;
 
   if(flags->verbose == 4){
-    fprintf(stdout,"[");
-    mpz_out_str(stdout, 10, c);
-    fprintf(stdout,",%lu]", k);
+    fprintf(VERBSTREAM,"[");
+    mpz_out_str(VERBSTREAM, 10, c);
+    fprintf(VERBSTREAM,",%lu]", k);
   }
   if(flags->verbose >= 5){
-    fprintf(stdout,"[");
-    mpz_out_str(stdout, 10, c);
-    fprintf(stdout,",%lu][bs=%lu]", k,
+    fprintf(VERBSTREAM,"[");
+    mpz_out_str(VERBSTREAM, 10, c);
+    fprintf(VERBSTREAM,",%lu][bs=%lu]", k,
             mpz_poly_max_bsize_coeffs(upol, *deg));
   }
 
@@ -836,8 +837,8 @@ static long bisection_rec(mpz_t *upol, unsigned long *deg,
       (*nbr)++;
 
       if(flags->verbose>=1){
-        fprintf(stdout,"+");
-        if((*nbr) % 100 == 0) fprintf(stdout, "[%lu]",(*nbr));
+        fprintf(VERBSTREAM,"+");
+        if((*nbr) % 100 == 0) fprintf(VERBSTREAM, "[%lu]",(*nbr));
       }
 
       if(flags->hasrealroots==1 && (*nbr)>0){
@@ -847,7 +848,7 @@ static long bisection_rec(mpz_t *upol, unsigned long *deg,
     }
 
     if(flags->verbose>=1){
-      fprintf(stdout,"!");
+      fprintf(VERBSTREAM,"!");
     }
     mpz_clear(tmp);
     return -1;
@@ -855,7 +856,7 @@ static long bisection_rec(mpz_t *upol, unsigned long *deg,
 
 
   if(flags->verbose>=2){
-    fprintf(stdout,"c");
+    fprintf(VERBSTREAM,"c");
   }
 
   e_time = realtime();
@@ -868,7 +869,7 @@ static long bisection_rec(mpz_t *upol, unsigned long *deg,
   flags->time_desc += (realtime()-e_time);
 
   if(flags->verbose>=3){
-    fprintf(stdout,"[nb=%lu]",nb);
+    fprintf(VERBSTREAM,"[nb=%lu]",nb);
   }
 
   if (bsgn == -1){
@@ -1065,13 +1066,13 @@ static inline void free_heap_flags(usolve_flags *flags,
 
 static void display_stats(usolve_flags *flags){
 
-  fprintf(stdout,"\n");
-  fprintf(stdout,"Number of nodes : %lu\n", flags->node_looked);
-  fprintf(stdout,"Number of shifts : %lu\n", flags->transl);
-  fprintf(stdout,"Number of half splits : %lu\n", flags->half_done);
-  fprintf(stdout,"Time in Descartes (elapsed): %.2f sec\n", flags->time_desc);
-  fprintf(stdout,"Time in Taylor shifts (elapsed): %.2f sec\n", flags->time_shift);
-  fprintf(stdout,"\n");
+  fprintf(VERBSTREAM,"\n");
+  fprintf(VERBSTREAM,"Number of nodes : %lu\n", flags->node_looked);
+  fprintf(VERBSTREAM,"Number of shifts : %lu\n", flags->transl);
+  fprintf(VERBSTREAM,"Number of half splits : %lu\n", flags->half_done);
+  fprintf(VERBSTREAM,"Time in Descartes (elapsed): %.2f sec\n", flags->time_desc);
+  fprintf(VERBSTREAM,"Time in Taylor shifts (elapsed): %.2f sec\n", flags->time_shift);
+  fprintf(VERBSTREAM,"\n");
 
 }
 
@@ -1110,7 +1111,7 @@ interval *bisection_Uspensky(mpz_t *upol0, unsigned long deg,
 
   if(mpz_sgn(upol0[0]) == 0 && mpz_sgn(upol0[1])==0){
 
-    fprintf(stderr,
+    fprintf(ERRSTREAM,
             "0 is a multiple root ; the input polynomial must be square-free\n");
 
     free(pos_roots);
@@ -1146,7 +1147,7 @@ interval *bisection_Uspensky(mpz_t *upol0, unsigned long deg,
     flags->bound_pos = bound_roots(upol, deg);
 
     if(flags->verbose>=1){
-      fprintf(stdout, "Bound for positive roots: %ld\n\n", flags->bound_pos);
+      fprintf(VERBSTREAM, "Bound for positive roots: %ld\n\n", flags->bound_pos);
     }
 
     USOLVEmpz_poly_rescale_normalize_2exp_th(upol,
@@ -1203,7 +1204,7 @@ interval *bisection_Uspensky(mpz_t *upol0, unsigned long deg,
                                              flags->nthreads);
 
     if(flags->verbose>=1){
-      fprintf(stdout, "\nBound for negative roots: %ld\n\n", flags->bound_neg);
+      fprintf(VERBSTREAM, "\nBound for negative roots: %ld\n\n", flags->bound_neg);
     }
 
     mpz_set_ui(e, 0);
@@ -1270,7 +1271,7 @@ interval *real_roots(mpz_t *upoly, unsigned long deg,
   flags->cur_deg = deg;
   flags->prec_isole = precision;
   if(info_level){
-    fprintf(stdout, "Real root isolation starts at precision %d\n",
+    fprintf(VERBSTREAM, "Real root isolation starts at precision %d\n",
             precision);
   }
   if (info_level > 0) {
@@ -1283,11 +1284,11 @@ interval *real_roots(mpz_t *upoly, unsigned long deg,
   }
   flags->nthreads = nthrds;
   if(flags->verbose>=1 || flags->print_stats == 1){
-    fprintf(stdout, "Degree = %ld \t Max bit size = %lu Min bit size = %lu \n",
+    fprintf(VERBSTREAM, "Degree = %ld \t Max bit size = %lu Min bit size = %lu \n",
             flags->cur_deg,
             mpz_poly_max_bsize_coeffs(upoly, deg),
             mpz_poly_min_bsize_coeffs(upoly, deg));
-    fprintf(stdout, "nthreads = %d\n", flags->nthreads);
+    fprintf(VERBSTREAM, "nthreads = %d\n", flags->nthreads);
   }
   double e_time = realtime ( );
 
@@ -1303,16 +1304,16 @@ interval *real_roots(mpz_t *upoly, unsigned long deg,
     }
   }
 
-  /* display_root(stderr, roots); */
+  /* display_root(ERRSTREAM, roots); */
 
   e_time = realtime ( ) - e_time;
 
   if(flags->verbose>=1){
-    fprintf(stdout, "\n");
+    fprintf(VERBSTREAM, "\n");
   }
 
   if((flags->verbose>=1) || (flags->print_stats>=1)){
-    fprintf(stdout,"Time for isolation (elapsed): %.2f sec\n", e_time);
+    fprintf(VERBSTREAM,"Time for isolation (elapsed): %.2f sec\n", e_time);
   }
 
   double refine_time = realtime();
@@ -1343,8 +1344,8 @@ interval *real_roots(mpz_t *upoly, unsigned long deg,
   }
 
   if((flags->verbose>=1) || (flags->print_stats>=1)){
-    fprintf(stdout,"Time for isolation (elapsed): %.2f sec\n", e_time);
-    fprintf(stdout,"Time for refinement (elapsed): %.2f sec\n", refine_time);
+    fprintf(VERBSTREAM,"Time for isolation (elapsed): %.2f sec\n", e_time);
+    fprintf(VERBSTREAM,"Time for refinement (elapsed): %.2f sec\n", refine_time);
   }
 
   free(flags);

--- a/src/usolve/utils.c
+++ b/src/usolve/utils.c
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <math.h>
+#include "../msolve/streams.h"
 
 #define bit_one_index(x) mpz_scan1((x), 0)
 
@@ -131,9 +132,9 @@ static void USOLVEnumer_quotient(mpz_t *upol, unsigned long int *deg, mpz_t c, u
 static inline void USOLVEmpz_poly_print(mpz_t *upol, unsigned long int deg){
   for(unsigned long int i=0; i<=deg; i++) {
     gmp_printf("%Zd", upol[i]);
-    fprintf(stdout," ");
+    fprintf(VERBSTREAM," ");
   }
-  fprintf(stdout, "\n");
+  fprintf(VERBSTREAM, "\n");
 }
 
 /* prints coefficients of pol in decreasing degree order */
@@ -141,10 +142,10 @@ static inline void USOLVEmpz_poly_print_maple(mpz_t *upol, unsigned long int deg
   int  i;
   for(i=deg;i>=1;i--){
     gmp_printf("(%Zd)", upol[i]);
-    fprintf(stdout,"*x^%d+",i);
+    fprintf(VERBSTREAM,"*x^%d+",i);
   }
   gmp_printf("(%Zd)", upol[0]);
-  fprintf(stdout, ";\n");
+  fprintf(VERBSTREAM, ";\n");
 }
 
 /* From the polynomial upol, of degree deg, and b>=0, computes (inplace)

--- a/test/fglm/build_matrixn_nonradical-radicalshape-31.c
+++ b/test/fglm/build_matrixn_nonradical-radicalshape-31.c
@@ -80,7 +80,7 @@ int main(void)
     success = initialize_gba_input_data(&bs, &bht, &st,gens->lens, gens->exps, (void *)gens->cfs,	1073741827, 0 /* DRL order */,elim_block_len, gens->nvars,/* gens->field_char,0 [> DRL order <], gens->nvars, */ gens->ngens, saturate,	initial_hts, nr_threads, max_pairs,	update_ht, la_option, use_signatures, 1 /* reduce_gb */, 0,	0/*truncate_lifting*/, info_level);
     bs = core_gba(bs, st, &error, 1073741827);
     if (!success || error) {
-      printf("Problem with F4, stopped computation.\n");
+        fprintf(ERRSTREAM, "Problem with F4, stopped computation.\n");
       return 104;
     }
 

--- a/test/fglm/build_matrixn_nonradical-shape-31.c
+++ b/test/fglm/build_matrixn_nonradical-shape-31.c
@@ -80,8 +80,8 @@ int main(void)
     success = initialize_gba_input_data(&bs, &bht, &st,gens->lens, gens->exps, (void *)gens->cfs,	1073741831, 0 /* DRL order */,elim_block_len, gens->nvars,/* gens->field_char,0 [> DRL order <], gens->nvars, */ gens->ngens, saturate,	initial_hts, nr_threads, max_pairs,	update_ht, la_option, use_signatures, 1 /* reduce_gb */, 0,	0/*truncate_lifitng*/, info_level);
     bs = core_gba(bs, st, &error, 1073741831);
     if (!success || error) {
-      printf("Problem with F4, stopped computation.\n");
-      return 104;
+        fprintf(ERRSTREAM, "Problem with F4, stopped computation.\n");
+        return 104;
     }
 
     export_results_from_gba(bld, blen, bexp,bcf, &malloc, &bs, &bht, &st);

--- a/test/fglm/build_matrixn_radical-shape-31.c
+++ b/test/fglm/build_matrixn_radical-shape-31.c
@@ -80,8 +80,8 @@ int main(void)
     success = initialize_gba_input_data(&bs, &bht, &st,gens->lens, gens->exps, (void *)gens->cfs,	1073741827, 0 /* DRL order */,elim_block_len, gens->nvars,/* gens->field_char,0 [> DRL order <], gens->nvars, */ gens->ngens, saturate,	initial_hts, nr_threads, max_pairs,	update_ht, la_option, use_signatures, 1 /* reduce_gb */, 0,	0 /*truncate_lifting*/, info_level);
     bs = core_gba(bs, st, &error, 1073741827);
     if (!success || error) {
-      printf("Problem with F4, stopped computation.\n");
-      return 104;
+        fprintf(ERRSTREAM, "Problem with F4, stopped computation.\n");
+        return 104;
     }
 
     export_results_from_gba(bld, blen, bexp,bcf, &malloc, &bs, &bht, &st);


### PR DESCRIPTION
This PR adds a file `src/msolve/streams.h` which has `#define` for different streams:

- the output stream, when it is not in a file, set to `stdout`,
- the verbose stream set to `stderr`
- and the error stream also set to `stderr`.
This should be easy to change later if we want to send them somewhere else.

Old commented `printf` have not been modified.

A similar stream could also be defined for debug messages, and for instance be also set to `stderr` with a `#define`.

This should fix #335 .