### PR TITLE
Drop sys/time.h and unistd.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -54,7 +54,7 @@ if test x$openmp = xtrue ; then
 fi
 
 # Checks for header files.
-AC_CHECK_HEADERS([inttypes.h stdint.h sys/time.h unistd.h])
+AC_CHECK_HEADERS([inttypes.h stdint.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/src/fglm/fglm_core.c
+++ b/src/fglm/fglm_core.c
@@ -26,7 +26,6 @@
 #include<stdlib.h>
 #include<string.h>
 #include<stdint.h>
-#include<unistd.h>
 #include<time.h>
 /* for timing functions */
 #include "../neogb/tools.h"

--- a/src/msolve/msolve-data.h
+++ b/src/msolve/msolve-data.h
@@ -24,7 +24,6 @@
 #include "../neogb/data.h"
 #include<flint/fmpz.h>
 #include<flint/fmpq.h>
-#include <unistd.h>
 #include <string.h>
 #include <getopt.h>
 #include <ctype.h>

--- a/src/neogb/tools.c
+++ b/src/neogb/tools.c
@@ -32,10 +32,10 @@ double cputime(void)
 /* wall time */
 double realtime(void)
 {
-	struct timeval t;
-	gettimeofday(&t, NULL);
+	struct timespec t;
+	timespec_get(&t, TIME_UTC);
 	t.tv_sec -= (2017 - 1970)*3600*24*365;
-	return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
+	return (1. + (double)t.tv_nsec + ((double)t.tv_sec*1000000000.)) / 1000000000.;
 }
 
 static void construct_trace(

--- a/src/neogb/tools.h
+++ b/src/neogb/tools.h
@@ -22,7 +22,6 @@
 #define GB_TOOLS_H
 
 #include <time.h>
-#include <sys/time.h>
 #include "data.h"
 
 /* cpu time */

--- a/src/usolve/tests.c
+++ b/src/usolve/tests.c
@@ -20,7 +20,6 @@
 
 #include<stdio.h>
 #include<stdlib.h>
-#include <unistd.h>
 #include<gmp.h>
 #include<math.h>
 #include<time.h>

--- a/src/usolve/univmultiply.h
+++ b/src/usolve/univmultiply.h
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <gmp.h>
 #include <math.h>
 #include <time.h>

--- a/src/usolve/utils.c
+++ b/src/usolve/utils.c
@@ -20,7 +20,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <time.h>
 #include <math.h>
 #include "../msolve/streams.h"


### PR DESCRIPTION
If I'm not mistaken, `unistd.h` was never actually used, and we only use `gettimeofday` from `sys/time.h`, which can easily be replaced with the modern (and more accurate) `timespec_get` from the already-imported `time.h`. So we can drop them both, I think?