### PR TITLE
Add fallback for timespec_get

### DIFF
--- a/src/neogb/tools.c
+++ b/src/neogb/tools.c
@@ -20,6 +20,21 @@
 
 #include "tools.h"
 
+/* timespec_get (C11) is not available on older Android and macOS targets.
+   For those targets, we fall back to gettimeofday. */
+#if defined(__ANDROID__) && defined(__ANDROID_API__) && __ANDROID_API__ < 29
+#define HAVE_TIMESPEC_GET 0
+#elif defined(__APPLE__) && defined(__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__) && \
+    __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ < 101500
+#define HAVE_TIMESPEC_GET 0
+#else
+#define HAVE_TIMESPEC_GET 1
+#endif
+
+#if !HAVE_TIMESPEC_GET
+#include <sys/time.h>
+#endif
+
 /* cpu time */
 double cputime(void)
 {
@@ -32,10 +47,17 @@ double cputime(void)
 /* wall time */
 double realtime(void)
 {
+#if !HAVE_TIMESPEC_GET
+	struct timeval t;
+	gettimeofday(&t, NULL);
+	t.tv_sec -= (2017 - 1970)*3600*24*365;
+	return (1. + (double)t.tv_usec + ((double)t.tv_sec*1000000.)) / 1000000.;
+#else
 	struct timespec t;
 	timespec_get(&t, TIME_UTC);
 	t.tv_sec -= (2017 - 1970)*3600*24*365;
 	return (1. + (double)t.tv_nsec + ((double)t.tv_sec*1000000000.)) / 1000000000.;
+#endif
 }
 
 static void construct_trace(


### PR DESCRIPTION
As discovered in Yggdrasil and vcpkg, the C11 `timespec_get` is not available for older (but somehow still used) targets such as OS X Yosemite (released in 2014) or Android 9 Pie (released in 2018). For those targets, there's no other choice than to use `gettimeofday` instead of `timespec_get`.