### PR TITLE
Drop function pointers in neogb

### DIFF
--- a/src/neogb/data.c
+++ b/src/neogb/data.c
@@ -21,97 +21,97 @@
 
 #include "data.h"
 
-/* function pointers */
-/* bs_t *(*initialize_basis)(
+/* functions */
+/* bs_t *initialize_basis(
  *         const int32_t ngens
  *         ); */
-void (*normalize_initial_basis)(
+void normalize_initial_basis(
         bs_t *bs,
         const uint32_t fc
-        ) = dispatch_normalize_initial_basis;
+        );
 
-int (*initial_input_cmp)(
+int initial_input_cmp(
         const void *a,
         const void *b,
         void *ht
-        ) = dispatch_initial_input_cmp;
+        );
 
-int (*initial_gens_cmp)(
+int initial_gens_cmp(
         const void *a,
         const void *b,
         void *ht
-        ) = dispatch_initial_gens_cmp;
+        );
 
-int (*monomial_cmp)(
+int monomial_cmp(
         const hi_t a,
         const hi_t b,
         const ht_t *ht
-        ) = dispatch_monomial_cmp;
+        );
 
-int (*spair_cmp)(
+int spair_cmp(
         const void *a,
         const void *b,
         void *htp
-        ) = dispatch_spair_cmp;
+        );
 
-int (*hcm_cmp)(
+int hcm_cmp(
         const void *a,
         const void *b,
         void *htp
-        ) = dispatch_hcm_cmp;
+        );
 
 /* linear algebra routines */
-void (*sba_linear_algebra)(
+void sba_linear_algebra(
         smat_t *smat,
         crit_t *syz,
         md_t *st,
         const ht_t * const ht
-        ) = dispatch_sba_linear_algebra;
+        );
 
-void (*exact_linear_algebra)(
+void exact_linear_algebra(
         mat_t *mat,
         const bs_t * const tbr,
         const bs_t * const bs,
         md_t *st
-        ) = dispatch_exact_linear_algebra;
+        );
 
-void (*linear_algebra)(
+void linear_algebra(
         mat_t *mat,
         const bs_t * const tbr,
         const bs_t * const bs,
         md_t *st
-        ) = dispatch_linear_algebra;
+        );
 
-int (*application_linear_algebra)(
+int application_linear_algebra(
         mat_t *mat,
         const bs_t * const bs,
         md_t *st
-        ) = dispatch_application_linear_algebra;
+        );
 
-void (*trace_linear_algebra)(
+void trace_linear_algebra(
         trace_t *trace,
         mat_t *mat,
         const bs_t * const bs,
         md_t *st
-        ) = dispatch_trace_linear_algebra;
+        );
 
-void (* interreduce_matrix_rows)(
+void interreduce_matrix_rows(
         mat_t *mat,
         bs_t *bs,
         md_t *st,
         int free_basis
-        ) = dispatch_interreduce_matrix_rows;
+        );
 
-cf32_t *(*reduce_dense_row_by_old_pivots_ff_32)(
+cf32_t *reduce_dense_row_by_old_pivots_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
         hm_t * const * const pivs,
         const hi_t dpiv,
         const uint32_t fc
-        ) = dispatch_reduce_dense_row_by_old_pivots_ff_32;
+        );
 
-hm_t *(*sba_reduce_dense_row_by_known_pivots_sparse_ff_32)(
+hm_t *sba_reduce_dense_row_by_known_pivots_sparse_ff_32(
         int64_t *dr,
         smat_t *smat,
         hm_t *const *pivs,
@@ -120,9 +120,9 @@ hm_t *(*sba_reduce_dense_row_by_known_pivots_sparse_ff_32)(
         const len_t si,     /* signature index of row reduced */
         const len_t ri,     /* index of row in matrix */
         md_t *st
-        ) = dispatch_sba_reduce_dense_row_by_known_pivots_sparse_ff_32;
+        );
 
-hm_t *(*reduce_dense_row_by_known_pivots_sparse_ff_32)(
+hm_t *reduce_dense_row_by_known_pivots_sparse_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -133,9 +133,9 @@ hm_t *(*reduce_dense_row_by_known_pivots_sparse_ff_32)(
         const len_t bi,     /* basis index of generating element */
         const len_t tr,     /* trace data? */
         md_t *st
-        ) = dispatch_reduce_dense_row_by_known_pivots_sparse_ff_32;
+        );
 
-hm_t *(*trace_reduce_dense_row_by_known_pivots_sparse_ff_32)(
+hm_t *trace_reduce_dense_row_by_known_pivots_sparse_ff_32(
         rba_t *rba,
         int64_t *dr,
         mat_t *mat,
@@ -146,9 +146,9 @@ hm_t *(*trace_reduce_dense_row_by_known_pivots_sparse_ff_32)(
         const len_t mh,
         const len_t bi,
         md_t *st
-        ) = dispatch_trace_reduce_dense_row_by_known_pivots_sparse_ff_32;
+        );
 
-cf32_t *(*reduce_dense_row_by_all_pivots_ff_32)(
+cf32_t *reduce_dense_row_by_all_pivots_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -156,13 +156,13 @@ cf32_t *(*reduce_dense_row_by_all_pivots_ff_32)(
         hm_t *const *pivs,
         cf32_t *const *dpivs,
         const uint32_t fc
-        ) = dispatch_reduce_dense_row_by_all_pivots_ff_32;
+        );
 
 
-cf32_t *(*reduce_dense_row_by_dense_new_pivots_ff_32)(
+cf32_t *reduce_dense_row_by_dense_new_pivots_ff_32(
         int64_t *dr,
         len_t *pc,
         cf32_t * const * const pivs,
         const len_t ncr,
         const uint32_t fc
-        ) = dispatch_reduce_dense_row_by_dense_new_pivots_ff_32;
+        );

--- a/src/neogb/data.h
+++ b/src/neogb/data.h
@@ -436,165 +436,88 @@ struct md_t
     uint32_t nr_kernel_elts;
 };
 
-/* function pointers */
-/* extern bs_t *(*initialize_basis)(
+/* functions */
+/* extern bs_t *initialize_basis(
  *         const int32_t ngens
  *         ); */
-extern void (*normalize_initial_basis)(
+extern void normalize_initial_basis(
         bs_t *bs,
         const uint32_t fc
         );
 
-/* re-entrant dispatch wrappers */
-void dispatch_normalize_initial_basis(
-        bs_t *bs,
-        const uint32_t fc
-        );
-
-extern int (*initial_input_cmp)(
+extern int initial_input_cmp(
         const void *a,
         const void *b,
         void *ht
         );
 
-int dispatch_initial_input_cmp(
+extern int initial_gens_cmp(
         const void *a,
         const void *b,
         void *ht
         );
 
-extern int (*initial_gens_cmp)(
-        const void *a,
-        const void *b,
-        void *ht
-        );
-
-int dispatch_initial_gens_cmp(
-        const void *a,
-        const void *b,
-        void *ht
-        );
-
-extern int (*monomial_cmp)(
+extern int monomial_cmp(
         const hi_t a,
         const hi_t b,
         const ht_t *ht
         );
 
-int dispatch_monomial_cmp(
-        const hi_t a,
-        const hi_t b,
-        const ht_t *ht
-        );
-
-extern int (*spair_cmp)(
+extern int spair_cmp(
         const void *a,
         const void *b,
         void *htp
         );
 
-int dispatch_spair_cmp(
-        const void *a,
-        const void *b,
-        void *htp
-        );
-
-extern int (*hcm_cmp)(
-        const void *a,
-        const void *b,
-        void *htp
-        );
-
-int dispatch_hcm_cmp(
+extern int hcm_cmp(
         const void *a,
         const void *b,
         void *htp
         );
 
 /* linear algebra routines */
-extern void (*sba_linear_algebra)(
+extern void sba_linear_algebra(
         smat_t *smat,
         crit_t *syz,
         md_t *st,
         const ht_t * const ht
         );
 
-void dispatch_sba_linear_algebra(
-        smat_t *smat,
-        crit_t *syz,
-        md_t *st,
-        const ht_t * const ht
-        );
-
-extern void (*exact_linear_algebra)(
+extern void exact_linear_algebra(
         mat_t *mat,
         const bs_t * const tbr,
         const bs_t * const bs,
         md_t *st
         );
 
-void dispatch_exact_linear_algebra(
+extern void linear_algebra(
         mat_t *mat,
         const bs_t * const tbr,
         const bs_t * const bs,
         md_t *st
         );
 
-extern void (*linear_algebra)(
-        mat_t *mat,
-        const bs_t * const tbr,
-        const bs_t * const bs,
-        md_t *st
-        );
-
-void dispatch_linear_algebra(
-        mat_t *mat,
-        const bs_t * const tbr,
-        const bs_t * const bs,
-        md_t *st
-        );
-
-extern int (*application_linear_algebra)(
+extern int application_linear_algebra(
         mat_t *mat,
         const bs_t * const bs,
         md_t *st
         );
 
-int dispatch_application_linear_algebra(
-        mat_t *mat,
-        const bs_t * const bs,
-        md_t *st
-        );
-
-extern void (*trace_linear_algebra)(
+extern void trace_linear_algebra(
         trace_t *trace,
         mat_t *mat,
         const bs_t * const bs,
         md_t *st
         );
 
-void dispatch_trace_linear_algebra(
-        trace_t *trace,
-        mat_t *mat,
-        const bs_t * const bs,
-        md_t *st
-        );
-
-extern void (* interreduce_matrix_rows)(
+extern void  interreduce_matrix_rows(
         mat_t *mat,
         bs_t *bs,
         md_t *st,
         int free_basis
         );
 
-void dispatch_interreduce_matrix_rows(
-        mat_t *mat,
-        bs_t *bs,
-        md_t *st,
-        int free_basis
-        );
-
-extern cf32_t *(*reduce_dense_row_by_old_pivots_ff_32)(
+extern cf32_t *reduce_dense_row_by_old_pivots_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -603,16 +526,7 @@ extern cf32_t *(*reduce_dense_row_by_old_pivots_ff_32)(
         const uint32_t fc
         );
 
-cf32_t *dispatch_reduce_dense_row_by_old_pivots_ff_32(
-        int64_t *dr,
-        mat_t *mat,
-        const bs_t * const bs,
-        hm_t * const * const pivs,
-        const hi_t dpiv,
-        const uint32_t fc
-        );
-
-extern hm_t *(*sba_reduce_dense_row_by_known_pivots_sparse_ff_32)(
+extern hm_t *sba_reduce_dense_row_by_known_pivots_sparse_ff_32(
         int64_t *dr,
         smat_t *smat,
         hm_t *const *pivs,
@@ -623,18 +537,7 @@ extern hm_t *(*sba_reduce_dense_row_by_known_pivots_sparse_ff_32)(
         md_t *st
         );
 
-hm_t *dispatch_sba_reduce_dense_row_by_known_pivots_sparse_ff_32(
-        int64_t *dr,
-        smat_t *smat,
-        hm_t *const *pivs,
-        const hi_t dpiv,
-        const hm_t sm,
-        const len_t si,
-        const len_t ri,
-        md_t *st
-        );
-
-extern hm_t *(*reduce_dense_row_by_known_pivots_sparse_ff_32)(
+extern hm_t *reduce_dense_row_by_known_pivots_sparse_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -647,20 +550,7 @@ extern hm_t *(*reduce_dense_row_by_known_pivots_sparse_ff_32)(
         md_t *st
         );
 
-hm_t *dispatch_reduce_dense_row_by_known_pivots_sparse_ff_32(
-        int64_t *dr,
-        mat_t *mat,
-        const bs_t * const bs,
-        hm_t *const *pivs,
-        const hi_t dpiv,
-        const hm_t tmp_pos,
-        const len_t mh,
-        const len_t bi,
-        const len_t tr,
-        md_t *st
-        );
-
-extern hm_t *(*trace_reduce_dense_row_by_known_pivots_sparse_ff_32)(
+extern hm_t *trace_reduce_dense_row_by_known_pivots_sparse_ff_32(
         rba_t *rba,
         int64_t *dr,
         mat_t *mat,
@@ -673,20 +563,7 @@ extern hm_t *(*trace_reduce_dense_row_by_known_pivots_sparse_ff_32)(
         md_t *st
         );
 
-hm_t *dispatch_trace_reduce_dense_row_by_known_pivots_sparse_ff_32(
-        rba_t *rba,
-        int64_t *dr,
-        mat_t *mat,
-        const bs_t * const bs,
-        hm_t *const *pivs,
-        const hi_t dpiv,
-        const hm_t tmp_pos,
-        const len_t mh,
-        const len_t bi,
-        md_t *st
-        );
-
-extern cf32_t *(*reduce_dense_row_by_all_pivots_ff_32)(
+extern cf32_t *reduce_dense_row_by_all_pivots_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -696,26 +573,7 @@ extern cf32_t *(*reduce_dense_row_by_all_pivots_ff_32)(
         const uint32_t fc
         );
 
-cf32_t *dispatch_reduce_dense_row_by_all_pivots_ff_32(
-        int64_t *dr,
-        mat_t *mat,
-        const bs_t * const bs,
-        len_t *pc,
-        hm_t *const *pivs,
-        cf32_t *const *dpivs,
-        const uint32_t fc
-        );
-
-
-extern cf32_t *(*reduce_dense_row_by_dense_new_pivots_ff_32)(
-        int64_t *dr,
-        len_t *pc,
-        cf32_t * const * const pivs,
-        const len_t ncr,
-        const uint32_t fc
-        );
-
-cf32_t *dispatch_reduce_dense_row_by_dense_new_pivots_ff_32(
+extern cf32_t *reduce_dense_row_by_dense_new_pivots_ff_32(
         int64_t *dr,
         len_t *pc,
         cf32_t * const * const pivs,

--- a/src/neogb/io.c
+++ b/src/neogb/io.c
@@ -786,7 +786,7 @@ static inline int use_17_bit_reduction(
     return fc < ((uint32_t)1u << 18);
 }
 
-int dispatch_initial_input_cmp(
+int initial_input_cmp(
         const void *a,
         const void *b,
         void *htp
@@ -802,7 +802,7 @@ int dispatch_initial_input_cmp(
     return initial_input_cmp_drl(a, b, htp);
 }
 
-int dispatch_initial_gens_cmp(
+int initial_gens_cmp(
         const void *a,
         const void *b,
         void *htp
@@ -818,7 +818,7 @@ int dispatch_initial_gens_cmp(
     return initial_gens_cmp_drl(a, b, htp);
 }
 
-int dispatch_monomial_cmp(
+int monomial_cmp(
         const hi_t a,
         const hi_t b,
         const ht_t *ht
@@ -833,7 +833,7 @@ int dispatch_monomial_cmp(
     return monomial_cmp_drl(a, b, ht);
 }
 
-int dispatch_spair_cmp(
+int spair_cmp(
         const void *a,
         const void *b,
         void *htp
@@ -849,7 +849,7 @@ int dispatch_spair_cmp(
     return spair_cmp_drl(a, b, htp);
 }
 
-int dispatch_hcm_cmp(
+int hcm_cmp(
         const void *a,
         const void *b,
         void *htp
@@ -865,7 +865,7 @@ int dispatch_hcm_cmp(
     return hcm_cmp_pivots_drl(a, b, htp);
 }
 
-void dispatch_sba_linear_algebra(
+void sba_linear_algebra(
         smat_t *smat,
         crit_t *syz,
         md_t *st,
@@ -875,7 +875,7 @@ void dispatch_sba_linear_algebra(
     sba_linear_algebra_ff_32(smat, syz, st, ht);
 }
 
-void dispatch_linear_algebra(
+void linear_algebra(
         mat_t *mat,
         const bs_t * const tbr,
         const bs_t * const bs,
@@ -957,7 +957,7 @@ void dispatch_linear_algebra(
     }
 }
 
-void dispatch_exact_linear_algebra(
+void exact_linear_algebra(
         mat_t *mat,
         const bs_t * const tbr,
         const bs_t * const bs,
@@ -981,7 +981,7 @@ void dispatch_exact_linear_algebra(
     }
 }
 
-int dispatch_application_linear_algebra(
+int application_linear_algebra(
         mat_t *mat,
         const bs_t * const bs,
         md_t *st
@@ -998,7 +998,7 @@ int dispatch_application_linear_algebra(
     }
 }
 
-void dispatch_trace_linear_algebra(
+void trace_linear_algebra(
         trace_t *trace,
         mat_t *mat,
         const bs_t * const bs,
@@ -1019,7 +1019,7 @@ void dispatch_trace_linear_algebra(
     }
 }
 
-void dispatch_interreduce_matrix_rows(
+void interreduce_matrix_rows(
         mat_t *mat,
         bs_t *bs,
         md_t *st,
@@ -1043,7 +1043,7 @@ void dispatch_interreduce_matrix_rows(
     }
 }
 
-void dispatch_normalize_initial_basis(
+void normalize_initial_basis(
         bs_t *bs,
         const uint32_t fc
         )
@@ -1062,7 +1062,7 @@ void dispatch_normalize_initial_basis(
     normalize_initial_basis_ff_32(bs, fc);
 }
 
-cf32_t *dispatch_reduce_dense_row_by_old_pivots_ff_32(
+cf32_t *reduce_dense_row_by_old_pivots_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -1077,7 +1077,7 @@ cf32_t *dispatch_reduce_dense_row_by_old_pivots_ff_32(
     return reduce_dense_row_by_old_pivots_31_bit(dr, mat, bs, pivs, dpiv, fc);
 }
 
-hm_t *dispatch_sba_reduce_dense_row_by_known_pivots_sparse_ff_32(
+hm_t *sba_reduce_dense_row_by_known_pivots_sparse_ff_32(
         int64_t *dr,
         smat_t *smat,
         hm_t *const *pivs,
@@ -1092,7 +1092,7 @@ hm_t *dispatch_sba_reduce_dense_row_by_known_pivots_sparse_ff_32(
             dr, smat, pivs, dpiv, sm, si, ri, st);
 }
 
-hm_t *dispatch_reduce_dense_row_by_known_pivots_sparse_ff_32(
+hm_t *reduce_dense_row_by_known_pivots_sparse_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -1113,7 +1113,7 @@ hm_t *dispatch_reduce_dense_row_by_known_pivots_sparse_ff_32(
             dr, mat, bs, pivs, dpiv, tmp_pos, mh, bi, tr, st);
 }
 
-hm_t *dispatch_trace_reduce_dense_row_by_known_pivots_sparse_ff_32(
+hm_t *trace_reduce_dense_row_by_known_pivots_sparse_ff_32(
         rba_t *rba,
         int64_t *dr,
         mat_t *mat,
@@ -1134,7 +1134,7 @@ hm_t *dispatch_trace_reduce_dense_row_by_known_pivots_sparse_ff_32(
             rba, dr, mat, bs, pivs, dpiv, tmp_pos, mh, bi, st);
 }
 
-cf32_t *dispatch_reduce_dense_row_by_all_pivots_ff_32(
+cf32_t *reduce_dense_row_by_all_pivots_ff_32(
         int64_t *dr,
         mat_t *mat,
         const bs_t * const bs,
@@ -1150,7 +1150,7 @@ cf32_t *dispatch_reduce_dense_row_by_all_pivots_ff_32(
     return reduce_dense_row_by_all_pivots_31_bit(dr, mat, bs, pc, pivs, dpivs, fc);
 }
 
-cf32_t *dispatch_reduce_dense_row_by_dense_new_pivots_ff_32(
+cf32_t *reduce_dense_row_by_dense_new_pivots_ff_32(
         int64_t *dr,
         len_t *pc,
         cf32_t * const * const pivs,


### PR DESCRIPTION
#289 made function pointers immutable. Following up on that, this PR replaces those function pointers with the underlying functions.