### PR TITLE
Fix 32-bit overflow in exponent-vector indexing

### DIFF
--- a/src/msolve/iofiles.c
+++ b/src/msolve/iofiles.c
@@ -22,7 +22,7 @@
 
 #include "streams.h"
 
-static inline void store_exponent(const char *term, data_gens_ff_t *gens, int32_t pos)
+static inline void store_exponent(const char *term, data_gens_ff_t *gens, int64_t pos)
 {
     len_t i, j, k;
 
@@ -740,7 +740,7 @@ static inline void get_term(const char *line, char **prev_pos,
 /*assumes that coeffs in file fit in word size */
 static int get_coefficient_ff_and_term_from_line(char *line, int32_t nterms,
                                           int32_t field_char,
-                                          data_gens_ff_t *gens, int32_t pos){
+                                          data_gens_ff_t *gens, int64_t pos){
   char *prev_pos = NULL;
   size_t term_size = 50000;
   char *term  = (char *)malloc(term_size * sizeof(char));
@@ -773,8 +773,8 @@ static int get_coefficient_ff_and_term_from_line(char *line, int32_t nterms,
       iv_tmp  +=  field_char; //MS change int -> long int
     }
     gens->cfs[pos]  = (int32_t)iv_tmp;
-    store_exponent(term, gens, pos*gens->nvars);
-    for(int j = 1; j < nterms; j++){
+    store_exponent(term, gens, pos * (int64_t)gens->nvars);
+    for(int64_t j = 1; j < nterms; j++){
       get_term(line, &prev_pos, &term, &term_size);
       if (term != NULL) {
         cf_tmp  = (int64_t)strtol(term, NULL, 10);
@@ -796,7 +796,7 @@ static int get_coefficient_ff_and_term_from_line(char *line, int32_t nterms,
           cf_tmp  += field_char;
         }
         gens->cfs[pos+j] = (int32_t)cf_tmp;
-        store_exponent(term, gens, (pos+j)*gens->nvars);
+        store_exponent(term, gens, (pos + j) * (int64_t)gens->nvars);
       }
       //      store_exponent(term, basis, ht);
     }
@@ -874,7 +874,7 @@ static void inner_strterm_to_mpz(char *str, mpz_t *num, mpz_t *den){
 
 static int get_coefficient_mpz_and_term_from_line(char *line, int32_t nterms,
                                           int32_t field_char,
-                                          data_gens_ff_t *gens, int32_t pos){
+                                          data_gens_ff_t *gens, int64_t pos){
   char *prev_pos = NULL;
   size_t term_size = 50000;
   char *term  = (char *)malloc(term_size * sizeof(char));
@@ -884,11 +884,11 @@ static int get_coefficient_mpz_and_term_from_line(char *line, int32_t nterms,
   if(term != NULL){
 
     beginning_strterm_to_mpz(term, gens->mpz_cfs[pos], gens->mpz_cfs[pos+1]);
-    store_exponent(term, gens, pos/2*gens->nvars);
-    for(int j = 2; j < 2*nterms; j+=2){
+    store_exponent(term, gens, (pos / 2) * (int64_t)gens->nvars);
+    for(int64_t j = 2; j < 2*(int64_t)nterms; j+=2){
       get_term(line, &prev_pos, &term, &term_size);
       inner_strterm_to_mpz(term, gens->mpz_cfs[pos+j], gens->mpz_cfs[pos+j+1]);
-      store_exponent(term, gens, ((pos+j)/2)*gens->nvars);
+      store_exponent(term, gens, ((pos + j) / 2) * (int64_t)gens->nvars);
     }
     free(term);
     return 0;
@@ -900,7 +900,7 @@ static int get_coefficient_mpz_and_term_from_line(char *line, int32_t nterms,
 
 static void get_coeffs_and_exponents_ff32(FILE *fh, nelts_t all_nterms,
         int32_t *nr_gens, data_gens_ff_t *gens){
-    int32_t pos = 0;
+    int64_t pos = 0;
     size_t size;
     ssize_t len;
 
@@ -910,8 +910,8 @@ static void get_coeffs_and_exponents_ff32(FILE *fh, nelts_t all_nterms,
     if(getline(&line, &size, fh) !=-1){
     }
 
-    gens->cfs = (int32_t *)(malloc(sizeof(int32_t) * all_nterms));
-    gens->exps = (int32_t *)calloc(all_nterms * gens->nvars, sizeof(int32_t));
+    gens->cfs = (int32_t *)(malloc(sizeof(int32_t) * (size_t)all_nterms));
+    gens->exps = (int32_t *)calloc((size_t)all_nterms * (size_t)gens->nvars, sizeof(int32_t));
     for (int32_t i = 0; i < *nr_gens; i++) {
         do {
             len = getdelim(&line, &size, ',', fh);
@@ -940,7 +940,7 @@ static void get_coeffs_and_exponents_ff32(FILE *fh, nelts_t all_nterms,
 
 static void get_coeffs_and_exponents_mpz(FILE *fh, nelts_t all_nterms,
         int32_t *nr_gens, data_gens_ff_t *gens){
-    int32_t pos = 0;
+    int64_t pos = 0;
     size_t size;
     ssize_t len;
 
@@ -950,15 +950,15 @@ static void get_coeffs_and_exponents_mpz(FILE *fh, nelts_t all_nterms,
     if(getline(&line, &size, fh) !=-1){
     }
 
-    gens->cfs = (int32_t*)(malloc(sizeof(int32_t) * all_nterms));
+    gens->cfs = (int32_t*)(malloc(sizeof(int32_t) * (size_t)all_nterms));
 
-    gens->mpz_cfs = (mpz_t **)(malloc(sizeof(mpz_t *) * 2 * all_nterms));
-    for(long i = 0; i < 2 * all_nterms; i++){
+    gens->mpz_cfs = (mpz_t **)(malloc(sizeof(mpz_t *) * 2 * (size_t)all_nterms));
+    for(long i = 0; i < 2 * (long)all_nterms; i++){
       gens->mpz_cfs[i]  = (mpz_t *)malloc(sizeof(mpz_t));
       mpz_init(*(gens->mpz_cfs[i]));
     }
 
-    gens->exps = (int32_t *)calloc(all_nterms * gens->nvars, sizeof(int32_t));
+    gens->exps = (int32_t *)calloc((size_t)all_nterms * (size_t)gens->nvars, sizeof(int32_t));
     for (int32_t i = 0; i < *nr_gens; i++) {
         do {
             len = getdelim(&line, &size, ',', fh);

--- a/src/msolve/msolve.c
+++ b/src/msolve/msolve.c
@@ -436,7 +436,8 @@ static inline void display_monomials_from_array_maple(FILE *file, long length,
  * new variable. */
 static int undo_variable_order_change(data_gens_ff_t *gens) {
   int32_t i, j;
-  int32_t len, tmp;
+  int64_t len;
+  int32_t tmp;
   char *tmp_char = NULL;
   const int32_t cvo = gens->change_var_order;
   const int32_t nvars = gens->nvars;
@@ -454,12 +455,12 @@ static int undo_variable_order_change(data_gens_ff_t *gens) {
     tmp = 0;
     for (i = 0; i < ngens; ++i) {
       for (j = 0; j < gens->lens[i]; ++j) {
-        tmp = gens->exps[len + j * nvars + nvars - 1];
-        gens->exps[len + j * nvars + nvars - 1] =
-            gens->exps[len + j * nvars + cvo];
-        gens->exps[len + j * nvars + cvo] = tmp;
+        tmp = gens->exps[len + (int64_t)j * nvars + nvars - 1];
+        gens->exps[len + (int64_t)j * nvars + nvars - 1] =
+            gens->exps[len + (int64_t)j * nvars + cvo];
+        gens->exps[len + (int64_t)j * nvars + cvo] = tmp;
       }
-      len += gens->lens[i] * nvars;
+      len += (int64_t)gens->lens[i] * nvars;
     }
   }
   /* all cyclic changes already done, stop here, try to add
@@ -474,7 +475,8 @@ static int undo_variable_order_change(data_gens_ff_t *gens) {
 static int change_variable_order_in_input_system(data_gens_ff_t *gens,
                                                  int32_t info_level) {
   int32_t i, j;
-  int32_t len, tmp;
+  int64_t len;
+  int32_t tmp;
   char *tmp_char = NULL;
   const int32_t cvo = gens->change_var_order;
   const int32_t nvars = gens->nvars;
@@ -490,12 +492,12 @@ static int change_variable_order_in_input_system(data_gens_ff_t *gens,
   tmp = 0;
   for (i = 0; i < gens->ngens; ++i) {
     for (j = 0; j < gens->lens[i]; ++j) {
-      tmp = gens->exps[len + j * nvars + nvars - 1];
-      gens->exps[len + j * nvars + nvars - 1] =
-          gens->exps[len + j * nvars + cvo + 1];
-      gens->exps[len + j * nvars + cvo + 1] = tmp;
+      tmp = gens->exps[len + (int64_t)j * nvars + nvars - 1];
+      gens->exps[len + (int64_t)j * nvars + nvars - 1] =
+          gens->exps[len + (int64_t)j * nvars + cvo + 1];
+      gens->exps[len + (int64_t)j * nvars + cvo + 1] = tmp;
     }
-    len += gens->lens[i] * nvars;
+    len += (int64_t)gens->lens[i] * nvars;
   }
   if (info_level > 0) {
     fprintf(VERBSTREAM, "\nChanging variable order for possibly more generic staircase:\n");

--- a/src/neogb/io.c
+++ b/src/neogb/io.c
@@ -26,7 +26,7 @@
 static inline void set_exponent_vector(
         exp_t *ev,
         const int32_t *iev,  /* input exponent vectors */
-        const int32_t idx,
+        const int64_t idx,
         const ht_t *ht,
         const md_t *st
         )
@@ -42,12 +42,12 @@ static inline void set_exponent_vector(
     ev[ebl] = 0;
 
     for (i = 0; i < nev; ++i) {
-        ev[i+1] = (exp_t)(iev+(nv*idx))[i];
+        ev[i+1] = (exp_t)(iev+((int64_t)nv * idx))[i];
         /* degree */
         ev[0]   +=  ev[i+1];
     }
     for (i = nev; i < nv; ++i) {
-        ev[i+off] = (exp_t)(iev+(nv*idx))[i];
+        ev[i+off] = (exp_t)(iev+((int64_t)nv * idx))[i];
         /* degree */
         ev[ebl]    +=  ev[i+off];
     }


### PR DESCRIPTION
On inputs whose total number of terms times the number of variables exceeds `INT32_MAX`, msolve segfaults while parsing: `(pos+j)*nvars` is evaluated in 32-bit signed arithmetic, so `store_exponent()` is called with a negative offset (`gdb`: `pos=-2147477296` at `iofiles.c:58`, called from `get_coefficient_ff_and_term_from_line`).

This patch uses 64-bit indexing for exponent-vector offsets and allocations (parser, F4 import, and the variable-order swap).

Minimized reproducer (10000 variables, 214750 terms of `x0` over a prime field, ~700KB): unpatched 0.10.1 dies with the backtrace above; patched computes a Groebner basis. `make check`: 64/64 pass.